### PR TITLE
README: Add OSX build instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -97,6 +97,16 @@ context where it sees non-index-oids, which causes it to croak:
 Now this is more of a curiosity than a bug, but maybe someday SQLsmith
 finds a real one...
 
+** Building on OSX
+
+In order to build on Mac OSX, assuming you use Homebrew, run the following
+
+: brew install libpqxx automake libtool autoconf autoconf-archive
+: cd sqlsmith
+: autoreconf -i
+: ./configure
+: make sqlsmith
+
 ** License
 
 See COPYING for using and distributing this code.


### PR DESCRIPTION
First of all, thanks for creating `sqlsmith` - I've been following your `-hackers` reports and it seems like a very useful tool!

I've wanted to use it to test a Go-based Postgres proxy server I'm working on, and noticed that there aren't any instructions on how to use it on OSX.

This adds the instructions for the common setup (Homebrew), as well as the hint at the necessary `autoreconf` call.

Let me know what you think :)