### PR TITLE
Add an "exclude-catalog" option.

### DIFF
--- a/postgres.cc
+++ b/postgres.cc
@@ -102,7 +102,7 @@ void dut_pqxx::test(const std::string &stmt)
 }
 
 
-schema_pqxx::schema_pqxx(std::string &conninfo) : c(conninfo)
+schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 {
   pqxx::work w(c);
 
@@ -154,10 +154,9 @@ schema_pqxx::schema_pqxx(std::string &conninfo) : c(conninfo)
     string schema(row[1].as<string>());
     string insertable(row[2].as<string>());
     string table_type(row[3].as<string>());
-    //       if (schema == "pg_catalog")
-    // 	continue;
-    //       if (schema == "information_schema")
-    // 	continue;
+
+	if (no_catalog && ((schema == "pg_catalog") || (schema == "information_schema")))
+		continue;
       
     tables.push_back(table(row[0].as<string>(),
 			   schema,

--- a/postgres.hh
+++ b/postgres.hh
@@ -43,7 +43,7 @@ struct schema_pqxx : public schema {
   virtual std::string quote_name(const std::string &id) {
     return c.quote_name(id);
   }
-  schema_pqxx(std::string &conninfo);
+  schema_pqxx(std::string &conninfo, bool no_catalog);
 };
 
 struct dut_pqxx : dut_base {

--- a/sqlite.cc
+++ b/sqlite.cc
@@ -85,25 +85,32 @@ sqlite_connection::~sqlite_connection()
     sqlite3_close(db);
 }
 
-schema_sqlite::schema_sqlite(std::string &conninfo)
+schema_sqlite::schema_sqlite(std::string &conninfo, bool no_catalog)
   : sqlite_connection(conninfo)
 {
+	std::string query = "SELECT * FROM main.sqlite_master where type in ('table', 'view')";
+
+	if (no_catalog)
+		query+= " AND name NOT like 'sqlite_%%'";
   
   version = "SQLite " SQLITE_VERSION " " SQLITE_SOURCE_ID;
 
 //   sqlite3_busy_handler(db, my_sqlite3_busy_handler, 0);
   cerr << "Loading tables...";
 
-  rc = sqlite3_exec(db, "SELECT * FROM main.sqlite_master where type in ('table', 'view')", table_callback, (void *)&tables, &zErrMsg);
+  rc = sqlite3_exec(db, query.c_str(), table_callback, (void *)&tables, &zErrMsg);
   if (rc!=SQLITE_OK) {
     auto e = std::runtime_error(zErrMsg);
     sqlite3_free(zErrMsg);
     throw e;
   }
 
-  // sqlite_master doesn't list itself, do it manually
-  table tab("sqlite_master", "main", false, false);
-  tables.push_back(tab);
+  if (!no_catalog)
+  {
+		// sqlite_master doesn't list itself, do it manually
+		table tab("sqlite_master", "main", false, false);
+		tables.push_back(tab);
+  }
   
   cerr << "done." << endl;
 

--- a/sqlite.hh
+++ b/sqlite.hh
@@ -22,7 +22,7 @@ struct sqlite_connection {
 };
 
 struct schema_sqlite : schema, sqlite_connection {
-  schema_sqlite(std::string &conninfo);
+  schema_sqlite(std::string &conninfo, bool no_catalog);
   virtual std::string quote_name(const std::string &id) {
     return id;
   }

--- a/sqlsmith.cc
+++ b/sqlsmith.cc
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
   cerr << PACKAGE_NAME " " GITREV << endl;
 
   map<string,string> options;
-  regex optregex("--(help|log-to|verbose|target|sqlite|version|dump-all-graphs|seed|dry-run|max-queries)(?:=((?:.|\n)*))?");
+  regex optregex("--(help|log-to|verbose|target|sqlite|version|dump-all-graphs|seed|dry-run|max-queries|exclude-catalog)(?:=((?:.|\n)*))?");
   
   for(char **opt = argv+1 ;opt < argv+argc; opt++) {
     smatch match;
@@ -81,6 +81,7 @@ int main(int argc, char *argv[])
       "    --seed=int           seed RNG with specified int instead of PID" << endl <<
       "    --dump-all-graphs    dump generated ASTs" << endl <<
       "    --dry-run            print queries instead of executing them" << endl <<
+      "    --exclude-catalog    don't generate queries using the catalog objects" << endl <<
       "    --max-queries=long   terminate after generating this many queries" << endl <<
       "    --verbose            emit progress output" << endl <<
       "    --version            print version information and exit" << endl <<
@@ -95,14 +96,14 @@ int main(int argc, char *argv[])
       shared_ptr<schema> schema;
       if (options.count("sqlite")) {
 #ifdef HAVE_LIBSQLITE3
-	schema = make_shared<schema_sqlite>(options["sqlite"]);
+	schema = make_shared<schema_sqlite>(options["sqlite"], options.count("exclude-catalog"));
 #else
 	cerr << "Sorry, " PACKAGE_NAME " was compiled without SQLite support." << endl;
 	return 1;
 #endif
       }
       else
-	schema = make_shared<schema_pqxx>(options["target"]);
+	schema = make_shared<schema_pqxx>(options["target"], options.count("exclude-catalog"));
 
       scope scope;
       long queries_generated = 0;


### PR DESCRIPTION
Hello,

In https://www.postgresql.org/message-id/flat/CAAeH1nBQhjBhkVL9ya4YrEu5zj-AupiPAH2R02C0OUVuqwWVow@mail.gmail.com#CAAeH1nBQhjBhkVL9ya4YrEu5zj-AupiPAH2R02C0OUVuqwWVow@mail.gmail.com someone complained that sqlsmith wasn't using his own tables.  The most likely reason is that there were much more catalog tables than user tables.  To avoid this problem, I added the exclude-catalog option.  It's been quite a long time since I wrote some C++, so I hope this patch is ok and the feature is wanted, otherwise feel free to reject this PR.