### PR TITLE
Added option flag to exclude certain statements

### DIFF
--- a/grammar.cc
+++ b/grammar.cc
@@ -465,22 +465,39 @@ upsert_stmt::upsert_stmt(prod *p, struct scope *s, table *v)
 
 shared_ptr<prod> statement_factory(struct scope *s)
 {
+  const auto check_d42 = [s](const std::string& stmt) {
+    return !s->excluded_stmts.count(stmt) && d42() == 1;
+  };
+
+  const auto check_d6 = [s](const int value, const std::string& stmt) {
+      return !s->excluded_stmts.count(stmt) && d6() > value;
+  };
+
   try {
     s->new_stmt();
-    if (d42() == 1)
+    if (check_d42("merge")) {
       return make_shared<merge_stmt>((struct prod *)0, s);
-    if (d42() == 1)
+    }
+
+    if (check_d42("insert")) {
       return make_shared<insert_stmt>((struct prod *)0, s);
-    else if (d42() == 1)
+    }
+    else if (check_d42("delete")) {
       return make_shared<delete_returning>((struct prod *)0, s);
-    else if (d42() == 1) {
+    }
+    else if (check_d42("upsert")) {
       return make_shared<upsert_stmt>((struct prod *)0, s);
-    } else if (d42() == 1)
+    }
+    else if (check_d42("update")) {
       return make_shared<update_returning>((struct prod *)0, s);
-    else if (d6() > 4)
+    }
+    else if (check_d6(4, "select_for_update")) {
       return make_shared<select_for_update>((struct prod *)0, s);
-    else if (d6() > 5)
+    }
+    else if (check_d6(5, "cte")) {
       return make_shared<common_table_expression>((struct prod *)0, s);
+    }
+
     return make_shared<query_spec>((struct prod *)0, s);
   } catch (runtime_error &e) {
     return statement_factory(s);

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_set>
 #include <utility>
 #include <memory>
 #include <cassert>
@@ -80,6 +81,7 @@ struct scope {
   struct scope *parent;
   vector<named_relation*> tables;  // available to table_ref productions
   vector<named_relation*> refs; // available to column_ref productions
+  std::unordered_set<string> excluded_stmts;
   struct schema *schema;
   shared_ptr<map<string,unsigned int> > stmt_seq; // sequence for stmt-unique identifiers
   scope(struct scope *parent = 0) : parent(parent) {


### PR DESCRIPTION
Great tool! As we are developing a PSQL DB plugin where certain statements are not supported, I wanted to exclude these. IMO my implementation is rather naive and I certainly can do better but I need to understand the code a bit more first. It currently focuses only on statements like UPDATE, DELETE, ...

I also took the liberty to switch the comparison to a lambda which increases maintainability IMO.

Potential improvements are:

- Restrict to only possible choices, and
- Change the lookup to a bitmask, haven't checked the impact on the query generation rate yet but I think it slows down.