### PR TITLE
[WIP] Replace mentions to proisagg and proiswindow with prokind instead

### DIFF
--- a/postgres.cc
+++ b/postgres.cc
@@ -210,7 +210,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "and proname <> 'pg_event_trigger_table_rewrite_reason' "
 	     "and proname <> 'pg_event_trigger_table_rewrite_oid' "
 	     "and proname !~ '^ri_fkey_' "
-	     "and not (proretset or proisagg or proiswindow) ");
+	     "and not (proretset or prokind = 'a' or prokind = 'w') ");
 
   for (auto row : r) {
     routine proc(row[0].as<string>(),
@@ -246,8 +246,8 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "and proname not in ('percentile_cont', 'dense_rank', 'cume_dist', "
 	     "'rank', 'test_rank', 'percent_rank', 'percentile_disc', 'mode', 'test_percentile_disc') "
 	     "and proname !~ '^ri_fkey_' "
-	     "and not (proretset or proiswindow) "
-	     "and proisagg");
+	     "and not (proretset or prokind = 'w') "
+	     "and prokind = 'a'");
 
   for (auto row : r) {
     routine proc(row[0].as<string>(),

--- a/schema.hh
+++ b/schema.hh
@@ -39,6 +39,7 @@ struct schema {
   std::vector<table*> base_tables;
 
   string version;
+  int version_num; // comparable version number
 
   const char *true_literal = "true";
   const char *false_literal = "false";


### PR DESCRIPTION
PostgreSQL recently introduced a catalog change, replacing both attributes `pg_proc.proisagg` and `pg_proc.proiswindow` with `pg_proc.prokind`.

However, this change as it is would break sqlsmith for any postgres version older than 11devel, which I assume is not desirable. How do you usually handle catalog changes? I couldn't figure it out easily by just grepping the source code.

Thanks in advance!