### PR TITLE
Add error symbol/code to sql output when logging output to database

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@ AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(LIBPQXX_CFLAGS) $(POSTGRESQL_CPPFLAGS) $(MONET
 EXTRA_DIST = gitrev.h dump.hh expr.hh grammar.hh log.hh prod.hh		\
     random.hh relmodel.hh schema.hh impedance.hh known.txt known_re.txt log.sql	\
     README.org TODO.org ast.png logo.png dump.xsl util.hh sqlite.hh	\
-    dut.hh postgres.hh monetdb.hh log-v1.0-to-v1.2.sql
+    dut.hh postgres.hh monetdb.hh log-v1.0-to-v1.2.sql log-v1.2-to-v1.3.sql
 
 gitrev.h: $(HEADERS) $(SOURCES)
 	-if git describe --dirty --tags --always > /dev/null ; then \

--- a/dut.hh
+++ b/dut.hh
@@ -13,30 +13,32 @@ namespace dut {
 struct failure : public std::exception {
   std::string errstr;
   std::string sqlstate;
+  std::string errcode;
   const char* what() const throw()
   {
     return errstr.c_str();
   }
-  failure(const char *s, const char *sqlstate_ = "") throw()
+  failure(const char *s, const char *sqlstate_ = "", const char *c = "e") throw()
        : errstr(), sqlstate() {
     errstr = s;
     sqlstate = sqlstate_;
+    errcode = c;
   };
 };
 
 struct broken : failure {
   broken(const char *s, const char *sqlstate_ = "") throw()
-    : failure(s, sqlstate_) { }
+    : failure(s, sqlstate_, "C") { }
 };
 
 struct timeout : failure {
   timeout(const char *s, const char *sqlstate_ = "") throw()
-    : failure(s, sqlstate_) { }
+    : failure(s, sqlstate_, "t") { }
 };
 
 struct syntax : failure {
   syntax(const char *s, const char *sqlstate_ = "") throw()
-    : failure(s, sqlstate_) { }
+    : failure(s, sqlstate_, "S") { }
 };
 
 }

--- a/log-v1.2-to-v1.3.sql
+++ b/log-v1.2-to-v1.3.sql
@@ -1,0 +1,8 @@
+-- upgrade SQLsmith logging schema from 1.2 to 1.3
+
+alter table error add column code char;
+
+create view base_error as
+    select id, firstline(msg) as error, query, code, t, errid from error;
+
+comment on view base_error is 'like error, but truncate msg to first line';

--- a/log.sql
+++ b/log.sql
@@ -22,7 +22,8 @@ create table error (
     query text,  -- failed query
     target text, -- conninfo of the target
     sqlstate text, -- sqlstate of error
-    
+    code char, -- error symbol from verbose output (C,e,S,t)
+
     -- not referenced by sqlsmith:
     t timestamptz default now(),
     errid bigserial primary key
@@ -57,7 +58,7 @@ create or replace function firstline(msg text) returns text as $$
 $$ language sql immutable;
 
 create view base_error as
-       select id, firstline(msg) as error, query, t, errid from error;
+       select id, firstline(msg) as error, query, code, t, errid from error;
 
 comment on view base_error is 'like error, but truncate msg to first line';
 


### PR DESCRIPTION
This PR just adds an additional column `code` to the `error` table and `base_error` view. The `code` is the same as the error symbol generated by enabling verbose output (`C`, `S`, `e`, `t`). Having the additional column allowed us to easily filter out the queries that were crashing the server. 

I wasn't really sure how to handle the database migration so I went ahead and created a v1.2 to v1.3 script but if you had something else in mind or want me to change column names just let me know.