### PR TITLE
Add privilege checks for Postgres

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,7 +133,7 @@ certain catalog view like this:
 This is because the planner then puts =pg_get_indexdef(oid)= in a
 context where it sees non-index-oids, which causes it to croak:
 
-:                                      QUERY PLAN                                     
+:                                      QUERY PLAN
 : ------------------------------------------------------------------------------------
 :  Hash Join  (cost=17.60..30.65 rows=9 width=4)
 :    Hash Cond: (i.oid = x.indexrelid)

--- a/dump.cc
+++ b/dump.cc
@@ -30,7 +30,7 @@ graphml_dumper::graphml_dumper(ostream &out)
             "attr.name=\"scope\" attr.type=\"string\" />" << endl;
 
   o << "<graph id=\"ast\" edgedefault=\"directed\">" << endl;
-  
+
 }
 
 void graphml_dumper::visit(struct prod *p)

--- a/dut.hh
+++ b/dut.hh
@@ -9,7 +9,7 @@
 #include "prod.hh"
 
 namespace dut {
-  
+
 struct failure : public std::exception {
   std::string errstr;
   std::string sqlstate;

--- a/expr.cc
+++ b/expr.cc
@@ -51,7 +51,7 @@ case_expr::case_expr(prod *p, sqltype *type_constraint)
 	  concrete one for a better match. */
        if (true_expr->type->consistent(false_expr->type))
 	    true_expr = value_expr::factory(this, false_expr->type);
-       else 
+       else
 	    false_expr = value_expr::factory(this, true_expr->type);
   }
   type = true_expr->type;
@@ -113,7 +113,7 @@ shared_ptr<bool_expr> bool_expr::factory(prod *p)
   }
   p->retry();
   return factory(p);
-     
+
 }
 
 exists_predicate::exists_predicate(prod *p) : bool_expr(p)
@@ -171,7 +171,7 @@ coalesce::coalesce(prod *p, sqltype *type_constraint, const char *abbrev)
     retry();
     if (first_expr->type->consistent(second_expr->type))
       first_expr = value_expr::factory(this, second_expr->type);
-    else 
+    else
       second_expr = value_expr::factory(this, first_expr->type);
   }
   type = second_expr->type;
@@ -179,7 +179,7 @@ coalesce::coalesce(prod *p, sqltype *type_constraint, const char *abbrev)
   value_exprs.push_back(first_expr);
   value_exprs.push_back(second_expr);
 }
- 
+
 void coalesce::out(std::ostream &out)
 {
   out << "cast(" << abbrev_ << "(";
@@ -196,7 +196,7 @@ const_expr::const_expr(prod *p, sqltype *type_constraint)
     : value_expr(p), expr("")
 {
   type = type_constraint ? type_constraint : scope->schema->inttype;
-      
+
   if (type == scope->schema->inttype)
     expr = to_string(d100());
   else if (type == scope->schema->booltype)
@@ -219,7 +219,7 @@ funcall::funcall(prod *p, sqltype *type_constraint, bool agg)
     : p->scope->schema->parameterless_routines_returning_type;
 
  retry:
-  
+
   if (!type_constraint) {
     proc = random_pick(idx.begin(), idx.end())->second;
   } else {
@@ -252,7 +252,7 @@ funcall::funcall(prod *p, sqltype *type_constraint, bool agg)
       retry();
       goto retry;
     }
-  
+
   for (auto argtype : proc->argtypes) {
     assert(argtype);
     auto expr = value_expr::factory(this, argtype);
@@ -324,7 +324,7 @@ void atomic_subselect::out(std::ostream &out)
     out << agg->ident() << "(" << col->name << ")";
   else
     out << col->name;
-  
+
   out << " from " << tab->ident();
 
   if (!agg)
@@ -338,7 +338,7 @@ void window_function::out(std::ostream &out)
 {
   indent(out);
   out << *aggregate << " over (partition by ";
-    
+
   for (auto ref = partition_by.begin(); ref != partition_by.end(); ref++) {
     out << **ref;
     if (ref+1 != partition_by.end())
@@ -346,7 +346,7 @@ void window_function::out(std::ostream &out)
   }
 
   out << " order by ";
-    
+
   for (auto ref = order_by.begin(); ref != order_by.end(); ref++) {
     out << **ref;
     if (ref+1 != order_by.end())

--- a/grammar.cc
+++ b/grammar.cc
@@ -65,7 +65,7 @@ table_sample::table_sample(prod *p) : table_ref(p) {
     t = dynamic_cast<struct table*>(pick);
     retry();
   } while (!t || !t->is_base_table);
-  
+
   refs.push_back(make_shared<aliased_relation>(scope->stmt_uid("sample"), t));
   percent = 0.1 * d100();
   method = (d6() > 2) ? "system" : "bernoulli";
@@ -111,7 +111,7 @@ simple_join_cond::simple_join_cond(prod *p, table_ref &lhs, table_ref &rhs)
 {
 retry:
   named_relation *left_rel = &*random_pick(lhs.refs);
-  
+
   if (!left_rel->columns().size())
     { retry(); goto retry; }
 
@@ -319,10 +319,10 @@ query_spec::query_spec(prod *p, struct scope *s, bool lateral) :
 
   if (lateral)
     scope->refs = s->refs;
-  
+
   from_clause = make_shared<struct from_clause>(this);
   select_list = make_shared<struct select_list>(this);
-  
+
   set_quantifier = (d100() == 1) ? "distinct" : "";
 
   search = bool_expr::factory(this);
@@ -393,7 +393,7 @@ void insert_stmt::out(std::ostream &out)
   }
 
   out << "values (";
-  
+
   for (auto expr = value_exprs.begin();
        expr != value_exprs.end();
        expr++) {
@@ -457,7 +457,7 @@ upsert_stmt::upsert_stmt(prod *p, struct scope *s, table *v)
 
   if (!victim->constraints.size())
     fail("need table w/ constraint for upsert");
-    
+
   set_list = std::make_shared<struct set_list>(this, victim);
   search = bool_expr::factory(this);
   constraint = random_pick(victim->constraints);
@@ -579,7 +579,7 @@ void merge_stmt::accept(prod_visitor *v)
   join_condition->accept(v);
   for (auto p : clauselist)
     p->accept(v);
-    
+
 }
 
 when_clause::when_clause(merge_stmt *p)
@@ -612,7 +612,7 @@ when_clause_update::when_clause_update(merge_stmt *p)
   myscope.refs = scope->refs;
   scope = &myscope;
   scope->refs.push_back(&*(p->target_table_->refs[0]));
-  
+
   set_list = std::make_shared<struct set_list>(this, p->victim);
 }
 
@@ -680,4 +680,3 @@ shared_ptr<when_clause> when_clause::factory(struct merge_stmt *p)
   }
   return factory(p);
 }
-

--- a/grammar.hh
+++ b/grammar.hh
@@ -83,7 +83,7 @@ struct expr_join_cond : join_cond {
 };
 
 struct joined_table : table_ref {
-  virtual void out(std::ostream &out);  
+  virtual void out(std::ostream &out);
   joined_table(prod *p);
   std::string type;
   std::string alias;
@@ -258,7 +258,7 @@ struct update_stmt : modifying_stmt {
 
 struct when_clause : prod {
   bool matched;
-  shared_ptr<bool_expr> condition;  
+  shared_ptr<bool_expr> condition;
 //   shared_ptr<prod> merge_action;
   when_clause(struct merge_stmt *p);
   virtual ~when_clause() { }

--- a/impedance.cc
+++ b/impedance.cc
@@ -39,7 +39,7 @@ void impedance_feedback::error(prod &query, const dut::failure &e)
 }
 
 namespace impedance {
-  
+
 bool matched(const char *name)
 {
   if (100 > occurances_in_failed_query[name])

--- a/known.txt
+++ b/known.txt
@@ -463,6 +463,7 @@ ERROR:  new bit must be 0 or 1
 ERROR:  no binary output function available for type aclitem
 ERROR:  no current dictionary
 ERROR:  no manual manipulation of HSlot
+ERROR:  no replication origin is configured
 ERROR:  non-exclusive backup in progress
 ERROR:  non-exclusive backup in progress)
 ERROR:  null array element not allowed in this context

--- a/known_re.txt
+++ b/known_re.txt
@@ -22,11 +22,14 @@ Pager usage is off.
 ^ERROR:  Cannot use ".*": Badly formatted type
 ^ERROR:  Cannot use ".*": No such cipher algorithm
 ^ERROR:  Cannot use .*: No such hash algorithm
+^ERROR:  Function .* is currently not supported for Aurora
+^ERROR:  Function .* is currently not supported in Aurora
 ^ERROR:  NUMERIC precision \\d+ must be between \\d+ and \\d+
 ^ERROR:  Patchfield "[^"]*" does not exist
 ^ERROR:  Room .* does not exist
 ^ERROR:  Syntax error near
 ^ERROR:  \\d+ is outside the valid range for parameter
+^ERROR:  argument declared anyrange is not a range type but type anyrange*
 ^ERROR:  argument list must have even number of elements
 ^ERROR:  array size exceeds the maximum allowed
 ^ERROR:  attribute number \\d+ not found in view targetlist
@@ -59,6 +62,7 @@ Pager usage is off.
 ^ERROR:  conflicting values for.* field in formatting string:
 ^ERROR:  connection .* not available
 ^ERROR:  could not create file "pg_snapshots.*Cannot allocate memory
+^ERROR:  could not determine polymorphic type because input has type unknown*
 ^ERROR:  could not find array type for data type
 ^ERROR:  could not find member .* of opfamily 1976
 ^ERROR:  could not find tuple for trigger

--- a/log.cc
+++ b/log.cc
@@ -57,7 +57,7 @@ struct stats_visitor : prod_visitor {
 void stats_collecting_logger::generated(prod &query)
 {
   queries++;
-  
+
   stats_visitor v;
   query.accept(&v);
 
@@ -145,9 +145,9 @@ pqxx_logger::pqxx_logger(std::string target, std::string conninfo, struct schema
 
   ostringstream seed;
   seed << smith::rng;
-    
+
   result r = w.prepared("instance")(GITREV)(target)(hostname)(s.version)(seed.str()).exec();
-  
+
   id = r[0][0].as<long>(id);
 
   c->prepare("error",
@@ -184,4 +184,3 @@ void pqxx_logger::generated(prod &query)
     w.commit();
   }
 }
-

--- a/log.sql
+++ b/log.sql
@@ -22,7 +22,7 @@ create table error (
     query text,  -- failed query
     target text, -- conninfo of the target
     sqlstate text, -- sqlstate of error
-    
+
     -- not referenced by sqlsmith:
     t timestamptz default now(),
     errid bigserial primary key
@@ -125,7 +125,7 @@ begin
 	then
 	   return NULL;
         end if;
-	
+
 	if new.msg ~ ANY (select re from known_re)
         then
 	   return NULL;

--- a/monetdb.cc
+++ b/monetdb.cc
@@ -214,7 +214,7 @@ void dut_monetdb::test(const std::string &stmt)
 		     figure out actual syntax errors */
 
 		  static regex re_syntax("^syntax error,.*", regex::extended);
-		  
+
 		  if (mapi_error(dbh)==MERROR)
 		       throw dut::syntax(error_string, sqlstate);
 		  else if (mapi_error(dbh)==MTIMEOUT)

--- a/postgres.cc
+++ b/postgres.cc
@@ -110,8 +110,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
   cerr << "Loading types...";
 
   r = w.exec("select quote_ident(typname), oid, typdelim, typrelid, typelem, typarray, typtype "
-	     "from pg_type ");
-
+	     "from pg_type where has_type_privilege (oid, 'usage')");
   for (auto row = r.begin(); row != r.end(); ++row) {
     string name(row[0].as<string>());
     OID oid(row[1].as<OID>());
@@ -140,11 +139,14 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
   cerr << "done." << endl;
 
   cerr << "Loading tables...";
-  r = w.exec("select table_name, "
-		    "table_schema, "
-	            "is_insertable_into, "
-	            "table_type "
-	     "from information_schema.tables");
+  r = w.exec("SELECT table_name, table_schema, is_insertable_into, table_type "
+             "FROM information_schema.tables t "
+             "JOIN pg_class c "
+             "  ON t.table_name = c.relname "
+             "JOIN pg_namespace n "
+             "  ON n.oid = c.relnamespace AND n.nspname = table_schema "
+             "WHERE relkind IN ('r', 'm', 'p', 'v') "
+             "  AND has_table_privilege(c.oid, 'select') ");
 
   for (auto row = r.begin(); row != r.end(); ++row) {
     string schema(row[1].as<string>());
@@ -170,6 +172,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "from pg_attribute join pg_class c on( c.oid = attrelid ) "
 	     "join pg_namespace n on n.oid = relnamespace "
 	     "where not attisdropped "
+	     "AND has_column_privilege (c.oid, attname, 'select')"
 	     "and attname not in "
 	     "('xmin', 'xmax', 'ctid', 'cmin', 'cmax', 'tableoid', 'oid') ");
     q += " and relname = " + w.quote(t->name);
@@ -216,6 +219,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "where prorettype::regtype::text not in ('event_trigger', 'trigger', 'opaque', 'internal') "
 	     "and proname <> 'pg_event_trigger_table_rewrite_reason' "
 	     "and proname <> 'pg_event_trigger_table_rewrite_oid' "
+	     "and has_function_privilege(pg_proc.oid, 'execute') " 
 	     "and proname !~ '^ri_fkey_' "
 	     "and not (proretset or " + procedure_is_aggregate + " or " + procedure_is_window + ") ");
 

--- a/postgres.cc
+++ b/postgres.cc
@@ -32,7 +32,7 @@ bool pg_type::consistent(sqltype *rvalue)
   case 'r': /* range */
   case 'e': /* enum */
     return this == t;
-    
+
   case 'p':
     if (name == "anyarray") {
       return t->typelem_ != InvalidOid;
@@ -53,7 +53,7 @@ bool pg_type::consistent(sqltype *rvalue)
     } else {
       return false;
     }
-      
+
   default:
     throw std::logic_error("unknown typtype");
   }
@@ -111,7 +111,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 
   r = w.exec("select quote_ident(typname), oid, typdelim, typrelid, typelem, typarray, typtype "
 	     "from pg_type ");
-  
+
   for (auto row = r.begin(); row != r.end(); ++row) {
     string name(row[0].as<string>());
     OID oid(row[1].as<OID>());
@@ -145,7 +145,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	            "is_insertable_into, "
 	            "table_type "
 	     "from information_schema.tables");
-	     
+
   for (auto row = r.begin(); row != r.end(); ++row) {
     string schema(row[1].as<string>());
     string insertable(row[2].as<string>());
@@ -153,13 +153,13 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 
 	if (no_catalog && ((schema == "pg_catalog") || (schema == "information_schema")))
 		continue;
-      
+
     tables.push_back(table(row[0].as<string>(),
 			   schema,
 			   ((insertable == "YES") ? true : false),
 			   ((table_type == "BASE TABLE") ? true : false)));
   }
-	     
+
   cerr << "done." << endl;
 
   cerr << "Loading columns and constraints...";
@@ -190,7 +190,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
     for (auto row : w.exec(q)) {
       t->constraints.push_back(row[0].as<string>());
     }
-    
+
   }
   cerr << "done." << endl;
 
@@ -235,7 +235,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
     string q("select unnest(proargtypes) "
 	     "from pg_proc ");
     q += " where oid = " + w.quote(proc.specific_name);
-      
+
     r = w.exec(q);
     for (auto row : r) {
       sqltype *t = oid2type[row[0].as<OID>()];
@@ -272,7 +272,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
     string q("select unnest(proargtypes) "
 	     "from pg_proc ");
     q += " where oid = " + w.quote(proc.specific_name);
-      
+
     r = w.exec(q);
     for (auto row : r) {
       sqltype *t = oid2type[row[0].as<OID>()];
@@ -336,7 +336,7 @@ void dut_libpq::command(const std::string &stmt)
 	const char *sqlstate = PQresultErrorField(res, PG_DIAG_SQLSTATE);
 	if (!sqlstate || !strlen(sqlstate))
 	     sqlstate =  (CONNECTION_OK != PQstatus(conn)) ? "08000" : "?????";
-	
+
 	std::string error_string(errmsg);
 	std::string sqlstate_string(sqlstate);
 	PQclear(res);

--- a/prod.cc
+++ b/prod.cc
@@ -29,7 +29,7 @@ void prod::retry()
   impedance::retry(this);
   if (retries++ <= retry_limit)
     return;
-  
+
   impedance::limit(this);
   throw std::runtime_error(std::string("excessive retries in ")
 			   + typeid(*this).name());

--- a/random.hh
+++ b/random.hh
@@ -16,7 +16,7 @@ namespace smith {
 template<typename T> T& random_pick(std::vector<T>& container) {
   if (!container.size())
     throw std::runtime_error("No candidates available");
-  
+
   std::uniform_int_distribution<int> pick(0, container.size()-1);
   return container[pick(smith::rng)];
 }

--- a/schema.cc
+++ b/schema.cc
@@ -26,7 +26,7 @@ void schema::generate_indexes() {
       if(!r.argtypes.size())
 	parameterless_routines_returning_type.insert(pair<sqltype*, routine*>(type, &r));
     }
-    
+
     for (auto &t: tables) {
       for (auto &c: t.columns()) {
 	if (type->consistent(c.type)) {
@@ -51,7 +51,7 @@ void schema::generate_indexes() {
     if (t.is_base_table)
       base_tables.push_back(&t);
   }
-  
+
   cerr << "done." << endl;
 
   assert(booltype);

--- a/sqlite.cc
+++ b/sqlite.cc
@@ -17,7 +17,7 @@ using namespace std;
 
 static regex e_syntax("near \".*\": syntax error");
 static regex e_user_abort("callback requested query abort");
-  
+
 extern "C"  {
 #include <sqlite3.h>
 #include <unistd.h>
@@ -93,7 +93,7 @@ schema_sqlite::schema_sqlite(std::string &conninfo, bool no_catalog)
 
 	if (no_catalog)
 		query+= " AND name NOT like 'sqlite_%%'";
-  
+
   version = "SQLite " SQLITE_VERSION " " SQLITE_SOURCE_ID;
 
 //   sqlite3_busy_handler(db, my_sqlite3_busy_handler, 0);
@@ -112,7 +112,7 @@ schema_sqlite::schema_sqlite(std::string &conninfo, bool no_catalog)
 		table tab("sqlite_master", "main", false, false);
 		tables.push_back(tab);
   }
-  
+
   cerr << "done." << endl;
 
   cerr << "Loading columns and constraints...";
@@ -159,7 +159,7 @@ schema_sqlite::schema_sqlite(std::string &conninfo, bool no_catalog)
 
   BINOP(AND, INTEGER);
   BINOP(OR, INTEGER);
-  
+
 #define FUNC(n,r) do {							\
     routine proc("", "", sqltype::get(#r), #n);				\
     register_routine(proc);						\
@@ -282,7 +282,7 @@ void dut_sqlite::test(const std::string &stmt)
       else if (regex_match(zErrMsg, e_user_abort)) {
 	sqlite3_free(zErrMsg);
 	return;
-      } else 
+      } else
 	throw dut::failure(zErrMsg);
     } catch (dut::failure &e) {
       sqlite3_free(zErrMsg);
@@ -290,4 +290,3 @@ void dut_sqlite::test(const std::string &stmt)
     }
   }
 }
-

--- a/sqlsmith.cc
+++ b/sqlsmith.cc
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 
   map<string,string> options;
   regex optregex("--(help|log-to|verbose|target|sqlite|monetdb|version|dump-all-graphs|dump-all-queries|seed|dry-run|max-queries|rng-state|exclude-catalog)(?:=((?:.|\n)*))?");
-  
+
   for(char **opt = argv+1 ;opt < argv+argc; opt++) {
     smatch match;
     string s(*opt);
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
 	loggers.push_back(l);
 	signal(SIGINT, cerr_log_handler);
       }
-      
+
       if (options.count("dump-all-graphs"))
 	loggers.push_back(make_shared<ast_logger>());
 
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
       }
 
       shared_ptr<dut_base> dut;
-      
+
       if (options.count("sqlite")) {
 #ifdef HAVE_LIBSQLITE3
 	dut = make_shared<dut_sqlite>(options["sqlite"]);
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
 #endif
       }
       else if(options.count("monetdb")) {
-#ifdef HAVE_MONETDB	   
+#ifdef HAVE_MONETDB
 	dut = make_shared<dut_monetdb>(options["monetdb"]);
 #else
 	cerr << "Sorry, " PACKAGE_NAME " was compiled without MonetDB support." << endl;
@@ -201,13 +201,13 @@ int main(int argc, char *argv[])
 		global_cerr_logger->report();
 	      return 0;
 	    }
-	    
+
 	    /* Invoke top-level production to generate AST */
 	    shared_ptr<prod> gen = statement_factory(&scope);
 
 	    for (auto l : loggers)
 	      l->generated(*gen);
-	  
+
 	    /* Generate SQL from AST */
 	    ostringstream s;
 	    gen->out(s);


### PR DESCRIPTION
Many of the database objects were although visible in the catalog weren't usable (owing to privilege restrictions) and thus generated errors, which had to then be filtered out via known / known_re.

Instead it seems better to weed out the DB Objects (types / tables / functions / columns) that the SQLSmith user doesn't have 'usage' / 'execute' / 'select' access to, so as to have a better list of errors to begin working with.

All the functions used are supported in all the active Postgres versions (i.e. v9.3+) and so should be safe to rely upon.