### PR TITLE
Feature/support libpqxx7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,10 +3,19 @@ AC_LANG(C++)
 
 AM_INIT_AUTOMAKE(-Wall -Werror foreign)
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX_11(noext,mandatory)
 
 AX_LIB_POSTGRESQL()
-PKG_CHECK_MODULES(LIBPQXX, libpqxx >= 4.0)
+
+PKG_CHECK_MODULES(LIBPQXX, libpqxx < 7.0,
+        [AX_CXX_COMPILE_STDCXX_11(noext,mandatory)],
+        [PKG_CHECK_MODULES([LIBPQXX], [libpqxx >= 7.0],
+                 [libpqxx7=yes],
+                 []
+         )]
+)
+
+AS_IF([test "x$libpqxx7" = "xyes"], [AC_DEFINE([HAVE_LIBPQXX7], [1], [define if libpqxx >= 7 is used])], [])
+AS_IF([test "x$libpqxx7" = "xyes"], [AX_CXX_COMPILE_STDCXX_17(noext,mandatory)], [])
 
 PKG_CHECK_MODULES(MONETDB_MAPI, monetdb-mapi >= 11.23.0,
 		[AC_DEFINE([HAVE_MONETDB], [1], [define if the MonetDB client library is available])],

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ PKG_CHECK_MODULES(LIBPQXX, libpqxx < 7.0,
          )]
 )
 
+AS_IF([test "x$libpqxx7" = "xyes"], AC_MSG_NOTICE([libpqxx version >= 7 detected]), [])
 AS_IF([test "x$libpqxx7" = "xyes"], [AC_DEFINE([HAVE_LIBPQXX7], [1], [define if libpqxx >= 7 is used])], [])
 AS_IF([test "x$libpqxx7" = "xyes"], [AX_CXX_COMPILE_STDCXX_17(noext,mandatory)], [])
 

--- a/log.cc
+++ b/log.cc
@@ -146,7 +146,7 @@ pqxx_logger::pqxx_logger(std::string target, std::string conninfo, struct schema
   ostringstream seed;
   seed << smith::rng;
     
-  result r = w.prepared("instance")(GITREV)(target)(hostname)(s.version)(seed.str()).exec();
+  result r = w.exec_prepared("instance", GITREV, target, hostname, s.version, seed.str());
   
   id = r[0][0].as<long>(id);
 
@@ -169,7 +169,7 @@ void pqxx_logger::error(prod &query, const dut::failure &e)
   work w(*c);
   ostringstream s;
   s << query;
-  w.prepared("error")(e.what())(s.str())(e.sqlstate).exec();
+  w.exec_prepared("error", e.what(), s.str(), e.sqlstate);
   w.commit();
 }
 
@@ -180,7 +180,7 @@ void pqxx_logger::generated(prod &query)
     work w(*c);
     ostringstream s;
     impedance::report(s);
-    w.prepared("stat")(queries)(sum_height/queries)(sum_nodes/queries)(sum_retries/queries)(s.str()).exec();
+    w.exec_prepared("stat", queries, sum_height/queries, sum_nodes/queries, sum_retries/queries, s.str());
     w.commit();
   }
 }

--- a/log.cc
+++ b/log.cc
@@ -145,8 +145,12 @@ pqxx_logger::pqxx_logger(std::string target, std::string conninfo, struct schema
 
   ostringstream seed;
   seed << smith::rng;
-    
+
+#ifdef HAVE_LIBPQXX7
   result r = w.exec_prepared("instance", GITREV, target, hostname, s.version, seed.str());
+#else
+  result r = w.prepared("instance")(GITREV)(target)(hostname)(s.version)(seed.str()).exec();
+#endif
   
   id = r[0][0].as<long>(id);
 
@@ -169,7 +173,11 @@ void pqxx_logger::error(prod &query, const dut::failure &e)
   work w(*c);
   ostringstream s;
   s << query;
+#ifdef HAVE_LIBPQXX7
   w.exec_prepared("error", e.what(), s.str(), e.sqlstate);
+#else
+  w.prepared("error")(e.what())(s.str())(e.sqlstate).exec();
+#endif
   w.commit();
 }
 
@@ -180,7 +188,11 @@ void pqxx_logger::generated(prod &query)
     work w(*c);
     ostringstream s;
     impedance::report(s);
+#ifdef HAVE_LIBPQXX7
     w.exec_prepared("stat", queries, sum_height/queries, sum_nodes/queries, sum_retries/queries, s.str());
+#else
+    w.prepared("stat")(queries)(sum_height/queries)(sum_nodes/queries)(sum_retries/queries)(s.str()).exec();
+#endif
     w.commit();
   }
 }

--- a/postgres.cc
+++ b/postgres.cc
@@ -71,8 +71,10 @@ dut_pqxx::dut_pqxx(std::string conninfo)
 void dut_pqxx::test(const std::string &stmt)
 {
   try {
+#ifndef HAVE_LIBPQXX7
     if(!c.is_open())
        c.activate();
+#endif
 
     pqxx::work w(c);
     w.exec(stmt.c_str());
@@ -282,7 +284,11 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
     }
   }
   cerr << "done." << endl;
+#ifdef HAVE_LIBPQXX7
+  c.close();
+#else
   c.disconnect();
+#endif
   generate_indexes();
 }
 


### PR DESCRIPTION
Currently sqlsmith doesn't compile with libpqxx version >= 7, which is the default version on e.g. Fedora 34. There
is another pull request from @justinpryzby , but this doesn't work since libpqxx 7 requires C++17 which isn't enforced by autoconf yet in this case and fails at least here on my Fedora box.

Based on the changes of https://github.com/anse1/sqlsmith/pull/33 i've put together some backwards compatible changes which should allow to build sqlsmith again on all platforms. Tested on Ubuntu 18.04 (libpqxx 4), CentOS 7 (libpqxx 5) and Fedora 34 (libpqxx 7).
