### PR TITLE
CMake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.14)
+project(SQLsmith LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
+include(FeatureTests)
+
+Option(USE_UPSTREAM_LIBPQXX "Fetch and use libpqxx from Github.")
+
+
+
+# define our executable early, so we can set the properties, based on our dependencies
+add_executable(sqlsmith)
+target_sources(sqlsmith PRIVATE
+        relmodel.cc schema.cc random.cc prod.cc expr.cc grammar.cc log.cc dump.cc impedance.cc sqlsmith.cc postgres.cc)
+
+target_link_libraries(sqlsmith PostgreSQL::PostgreSQL)
+
+# Workaround for outdated cmake packages on debian
+set(PostgreSQL_ADDITIONAL_VERSIONS 11 12 13 14)
+find_package(PostgreSQL REQUIRED)
+
+if (NOT USE_UPSTREAM_LIBPQXX)
+    # If we use the system pqxx library, we have to check for libpq.
+    # This check is done by the CMakeLists.txt of the libpqxx project otherwise
+    find_package(PQXX REQUIRED)
+
+    if (PQXX_VERSION GREATER 7.0)
+        set(HAVE_LIBPQXX7 TRUE)
+    endif (PQXX_VERSION GREATER 7.0)
+
+    target_link_libraries(sqlsmith PQXX::PQXX)
+else (NOT USE_UPSTREAM_LIBPQXX)
+    set(SKIP_BUILD_TEST TRUE)
+    include(FetchContent)
+    FetchContent_Declare(
+            libpqxx
+            GIT_REPOSITORY https://github.com/jtv/libpqxx.git
+            GIT_TAG 7.6.0
+    )
+    FetchContent_MakeAvailable(libpqxx)
+    FetchContent_GetProperties(libpqxx)
+    unset(SKIP_BUILD_TEST)
+
+    set(HAVE_LIBPQXX7 TRUE)
+
+    target_include_directories(sqlsmith PRIVATE ${libpqxx_SOURCE_DIR}/include)
+    target_link_libraries(sqlsmith pqxx)
+endif (NOT USE_UPSTREAM_LIBPQXX)
+
+if(NOT std_regex_ok)
+    find_package(Boost REQUIRED COMPONENTS regex)
+    set(REGEX_LIBRARY Boost::regex)
+    set(HAVE_BOOST TRUE)
+    set(HAVE_BOOST_REGEX TRUE)
+endif(NOT std_regex_ok)
+
+## optional dependencies
+# sqlite
+find_package(SQLite3)
+if (SQLite3_FOUND)
+    set(HAVE_LIBSQLITE3 TRUE)
+    target_sources(sqlsmith PRIVATE sqlite.cc)
+    target_link_libraries(sqlsmith SQLite::SQLite3)
+endif ()
+
+# monetdb
+find_package(MonetDB)
+if (MonetDB_FOUND)
+    set(HAVE_MONETDB 1)
+    target_sources(sqlsmith PRIVATE monetdb.cc)
+    target_link_libraries(sqlsmith MonetDB::mapi)
+endif ()
+
+
+## target configuration
+string(TOLOWER ${PROJECT_NAME} PACKAGE)
+set(PACKAGE_NAME ${PROJECT_NAME})
+configure_file(config_h.cmake.in config.h)
+
+
+# get our git tag
+set(GIT_TAG UNRELEASED)
+execute_process(
+        COMMAND git describe --dirty --tags --always
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# our gitrev.h
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/gitrev.h "#define GITREV \"${GIT_TAG}\"")
+
+# make sure our target finds gitrev.h and config.h
+target_include_directories(sqlsmith PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/cmake/modules/FeatureTests.cmake
+++ b/cmake/modules/FeatureTests.cmake
@@ -1,0 +1,22 @@
+# borked std::regex
+
+include(CheckCXXSourceCompiles)
+
+# check for a broken std::regex
+check_cxx_source_compiles([=[
+#include <regex>
+#include <iostream>
+
+int main()
+{
+  std::regex re(".*OK.*");
+  auto ret = std::regex_match("This should be OK", re);
+  if (!ret) {
+    std::cout << "not_matched" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+]=] std_regex_ok
+        FAIL_REGEX not_matched)

--- a/cmake/modules/FindMonetDB.cmake
+++ b/cmake/modules/FindMonetDB.cmake
@@ -1,0 +1,79 @@
+# Distributed under the GPL-3.0 as part of SQLSmith.
+#[=======================================================================[.rst:
+FindMonetDB
+-------
+
+Finds the monetdb-mapi library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``MonetDB::mapi``
+  The monetdb-mapi library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``MonetDB_FOUND``
+  True if the system has the monetdb-mapi library.
+``MonetDB_VERSION``
+  The version of the monetdb-mapi library which was found.
+``MonetDB_INCLUDE_DIRS``
+  Include directories needed to use monetdb-mapi.
+``MonetDB_LIBRARIES``
+  Libraries needed to link to monetdb-mapi.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``MonetDB_INCLUDE_DIR``
+  The directory containing ``foo.h``.
+``MonetDB_LIBRARY``
+  The path to the Foo library.
+
+#]=======================================================================]
+
+find_package(PkgConfig)
+pkg_check_modules(PC_MonetDB QUIET monetdb-mapi)
+
+find_path(MonetDB_INCLUDE_DIR
+        NAMES mapi.h
+        PATHS ${PC_MonetDB_INCLUDE_DIRS}
+        PATH_SUFFIXES monetdb
+        )
+
+find_library(MonetDB_LIBRARY
+        NAMES mapi
+        PATHS ${PC_MonetDB_LIBRARY_DIRS}
+        )
+
+set(MonetDB_VERSION ${PC_MonetDB_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MonetDB
+        FOUND_VAR MonetDB_FOUND
+        REQUIRED_VARS
+            MonetDB_LIBRARY
+            MonetDB_INCLUDE_DIR
+        VERSION_VAR MonetDB_VERSION
+        )
+
+if (MonetDB_FOUND)
+    set(MonetDB_LIBRARIES ${MonetDB_LIBRARY})
+    set(MonetDB_INCLUDE_DIRS ${MonetDB_INCLUDE_DIR})
+    set(MonetDB_DEFINITIONS ${PC_MonetDB_CFLAGS_OTHER})
+
+    add_library(MonetDB::mapi UNKNOWN IMPORTED)
+    set_target_properties(MonetDB::mapi PROPERTIES
+            IMPORTED_LOCATION "${MonetDB_LIBRARY}"
+            INTERFACE_COMPILE_OPTIONS "${PC_MonetDB_CFLAGS_OTHER}"
+            INTERFACE_INCLUDE_DIRECTORIES "${MonetDB_INCLUDE_DIR}"
+            )
+endif ()
+

--- a/cmake/modules/FindPQXX.cmake
+++ b/cmake/modules/FindPQXX.cmake
@@ -1,0 +1,78 @@
+# Distributed under the GPL-3.0 as part of SQLSmith.
+#[=======================================================================[.rst:
+FindPQXX
+-------
+
+Finds the libpqxx library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``PQXX::PQXX``
+  The libpqxx library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``PQXX_FOUND``
+  True if the system has the libpqxx library.
+``PQXX_VERSION``
+  The version of the libpqxx library which was found.
+``PQXX_INCLUDE_DIRS``
+  Include directories needed to use libpqxx.
+``PQXX_LIBRARIES``
+  Libraries needed to link to libpqxx.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``PQXX_INCLUDE_DIR``
+  The directory containing ``foo.h``.
+``PQXX_LIBRARY``
+  The path to the Foo library.
+
+#]=======================================================================]
+
+find_package(PkgConfig)
+pkg_check_modules(PC_PQXX QUIET libpqxx)
+
+find_path(PQXX_INCLUDE_DIR
+        NAMES pqxx
+        PATHS ${PC_PQXX_INCLUDE_DIRS}
+        )
+
+find_library(PQXX_LIBRARY
+        NAMES pqxx
+        PATHS ${PC_PQXX_LIBRARY_DIRS}
+        )
+
+set(PQXX_VERSION ${PC_PQXX_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PQXX
+        FOUND_VAR PQXX_FOUND
+        REQUIRED_VARS
+            PQXX_LIBRARY
+            PQXX_INCLUDE_DIR
+        VERSION_VAR PQXX_VERSION
+        )
+
+if (PQXX_FOUND)
+    set(PQXX_LIBRARIES ${PQXX_LIBRARY})
+    set(PQXX_INCLUDE_DIRS ${PQXX_INCLUDE_DIR})
+    set(PQXX_DEFINITIONS ${PC_PQXX_CFLAGS_OTHER})
+
+    add_library(PQXX::PQXX UNKNOWN IMPORTED)
+    set_target_properties(PQXX::PQXX PROPERTIES
+            IMPORTED_LOCATION "${PQXX_LIBRARY}"
+            INTERFACE_COMPILE_OPTIONS "${PC_PQXX_CFLAGS_OTHER}"
+            INTERFACE_INCLUDE_DIRECTORIES "${PQXX_INCLUDE_DIR}"
+            )
+endif ()
+

--- a/config_h.cmake.in
+++ b/config_h.cmake.in
@@ -1,0 +1,16 @@
+/* we know these paramters as they are required during the CMake configure phase */
+#define HAVE_CXX17 1
+
+
+
+#cmakedefine HAVE_BOOST 1
+#cmakedefine HAVE_BOOST_REGEX 1
+
+#cmakedefine HAVE_LIBPQXX7 1
+
+#cmakedefine HAVE_LIBSQLITE3 1
+#cmakedefine HAVE_MONETDB 1
+
+#cmakedefine PACKAGE "@PACKAGE@"
+#cmakedefine PACKAGE_NAME "@PACKAGE_NAME@"
+


### PR DESCRIPTION
CMake build system support.

This is still WIP. ~~as MonetDB support is missing right now.~~

~~In difference to autotools, the CMake build path will fetch a defined version of libpqxx, and imports the library directly as target into the build process of SQLSmith.~~

*UPDATE*:
I reworked the whole CMake code. Now code from remote is only fetched if `-DUSE_UPSTREAM_LIBPQXX=ON`is provided during the cmake configure phase.

MonetDB support is now also implemented and tested.

*UPDATE*:
Windows builds work after some code changes. So, i would considere CMake Support complete. 