### PR TITLE
Minor (style) optimizations

### DIFF
--- a/dump.cc
+++ b/dump.cc
@@ -14,34 +14,34 @@ std::string graphml_dumper::id(struct prod *p)
 }
 
 graphml_dumper::graphml_dumper(ostream &out)
-  : o(out)
+    : o(out)
 {
-  o << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << endl <<
-    "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " <<
-    "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " <<
-    "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " <<
-    "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" << endl;
+  o << R"(<?xml version="1.0" encoding="UTF-8"?>)" << endl <<
+    R"(<graphml xmlns="http://graphml.graphdrawing.org/xmlns" )" <<
+    R"(xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" )" <<
+    R"(xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns )" <<
+    R"(http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">)" << endl;
 
-  o << "<key id=\"retries\" for=\"node\" "
-            "attr.name=\"retries\" attr.type=\"double\" />" << endl;
-  o << "<key id=\"label\" for=\"node\" "
-            "attr.name=\"label\" attr.type=\"string\" />" << endl;
-  o << "<key id=\"scope\" for=\"node\" "
-            "attr.name=\"scope\" attr.type=\"string\" />" << endl;
+  o << R"(<key id="retries" for="node" )"
+       R"(attr.name="retries" attr.type="double" />)" << endl;
+  o << R"(<key id="label" for="node" )"
+       R"(attr.name="label" attr.type="string" />)" << endl;
+  o << R"(<key id="scope" for="node" )"
+       R"(attr.name="scope" attr.type="string" />)" << endl;
 
-  o << "<graph id=\"ast\" edgedefault=\"directed\">" << endl;
-  
+  o << R"(<graph id="ast" edgedefault="directed">)" << endl;
+
 }
 
 void graphml_dumper::visit(struct prod *p)
 {
-  o << "<node id=\"" << id(p) <<  "\">";
-  o << "<data key=\"retries\">" << p->retries << "</data>";
-  o << "<data key=\"label\">" << pretty_type(p) << "</data>";
-  o << "<data key=\"scope\">" << p->scope << "</data>";
+  o << R"(<node id=")" << id(p) << R"(">)";
+  o << R"(<data key="retries">)" << p->retries << "</data>";
+  o << R"(<data key="label">)" << pretty_type(p) << "</data>";
+  o << R"(<data key="scope">)" << p->scope << "</data>";
   o << "</node>" << endl;
   if (p->pprod) {
-    o << "<edge source=\"" << id(p) << "\" target=\"" << id(p->pprod) << "\"/>";
+    o << R"(<edge source=")" << id(p) << R"(" target=")" << id(p->pprod) << R"("/>)";
   }
   o << endl;
 }

--- a/dump.cc
+++ b/dump.cc
@@ -53,7 +53,7 @@ graphml_dumper::~graphml_dumper()
 
 void ast_logger::generated(prod &query)
 {
-  string filename("");
+  string filename{};
   filename += "sqlsmith-";
   filename += to_string(queries);
   filename += ".xml";

--- a/dump.hh
+++ b/dump.hh
@@ -14,7 +14,7 @@ struct graphml_dumper : prod_visitor {
   std::ostream &o;
   virtual void visit(struct prod *p);
   graphml_dumper(std::ostream &out);
-  std::string id(prod *p);
+  static std::string id(prod *p);
   std::string type(struct prod *p);
   virtual ~graphml_dumper();
 };

--- a/dut.hh
+++ b/dut.hh
@@ -13,11 +13,11 @@ namespace dut {
 struct failure : public std::exception {
   std::string errstr;
   std::string sqlstate;
-  const char* what() const throw()
+  const char* what() const noexcept override
   {
     return errstr.c_str();
   }
-  failure(const char *s, const char *sqlstate_ = "") throw()
+  failure(const char *s, const char *sqlstate_ = "") noexcept
        : errstr(), sqlstate() {
     errstr = s;
     sqlstate = sqlstate_;
@@ -25,17 +25,17 @@ struct failure : public std::exception {
 };
 
 struct broken : failure {
-  broken(const char *s, const char *sqlstate_ = "") throw()
+  broken(const char *s, const char *sqlstate_ = "") noexcept
     : failure(s, sqlstate_) { }
 };
 
 struct timeout : failure {
-  timeout(const char *s, const char *sqlstate_ = "") throw()
+  timeout(const char *s, const char *sqlstate_ = "") noexcept
     : failure(s, sqlstate_) { }
 };
 
 struct syntax : failure {
-  syntax(const char *s, const char *sqlstate_ = "") throw()
+  syntax(const char *s, const char *sqlstate_ = "") noexcept
     : failure(s, sqlstate_) { }
 };
 

--- a/expr.cc
+++ b/expr.cc
@@ -288,16 +288,16 @@ atomic_subselect::atomic_subselect(prod *p, sqltype *type_constraint)
       agg = &random_pick<>(scope->schema->aggregates);
     }
     if (agg->argtypes.size() != 1)
-      agg = 0;
+      agg = nullptr;
     else
       type_constraint = agg->argtypes[0];
   } else {
-    agg = 0;
+    agg = nullptr;
   }
 
   if (type_constraint) {
     auto idx = scope->schema->tables_with_columns_of_type;
-    col = 0;
+    col = nullptr;
     auto iters = idx.equal_range(type_constraint);
     tab = random_pick<>(iters)->second;
 

--- a/expr.cc
+++ b/expr.cc
@@ -374,7 +374,7 @@ window_function::window_function(prod *p, sqltype *type_constraint)
 bool window_function::allowed(prod *p)
 {
   if (dynamic_cast<select_list *>(p))
-    return dynamic_cast<query_spec *>(p->pprod) ? true : false;
+    return dynamic_cast<query_spec *>(p->pprod) != nullptr;
   if (dynamic_cast<window_function *>(p))
     return false;
   if (dynamic_cast<value_expr *>(p))

--- a/expr.cc
+++ b/expr.cc
@@ -29,7 +29,7 @@ shared_ptr<value_expr> value_expr::factory(prod *p, sqltype *type_constraint)
       return make_shared<atomic_subselect>(p, type_constraint);
     else if (p->level< d6() && d9()==1)
       return make_shared<case_expr>(p, type_constraint);
-    else if (p->scope->refs.size() && d20() > 1)
+    else if (!p->scope->refs.empty() && d20() > 1)
       return make_shared<column_reference>(p, type_constraint);
     else
       return make_shared<const_expr>(p, type_constraint);
@@ -193,7 +193,7 @@ void coalesce::out(std::ostream &out)
 }
 
 const_expr::const_expr(prod *p, sqltype *type_constraint)
-    : value_expr(p), expr("")
+    : value_expr(p)
 {
   type = type_constraint ? type_constraint : scope->schema->inttype;
       

--- a/expr.hh
+++ b/expr.hh
@@ -24,18 +24,18 @@ struct case_expr : value_expr {
   shared_ptr<value_expr> true_expr;
   shared_ptr<value_expr> false_expr;
   case_expr(prod *p, sqltype *type_constraint = 0);
-  virtual void out(std::ostream &out);
-  virtual void accept(prod_visitor *v);
+  void out(std::ostream &out) override;
+  void accept(prod_visitor *v) override;
 };
 
 struct funcall : value_expr {
   routine *proc;
   bool is_aggregate;
   vector<shared_ptr<value_expr> > parms;
-  virtual void out(std::ostream &out);
-  virtual ~funcall() { }
+  void out(std::ostream &out) override;
+  ~funcall() override { }
   funcall(prod *p, sqltype *type_constraint = 0, bool agg = 0);
-  virtual void accept(prod_visitor *v) {
+  void accept(prod_visitor *v) override {
     v->visit(this);
     for (auto p : parms)
       p->accept(v);
@@ -48,30 +48,30 @@ struct atomic_subselect : value_expr {
   int offset;
   routine *agg;
   atomic_subselect(prod *p, sqltype *type_constraint = 0);
-  virtual void out(std::ostream &out);
+  void out(std::ostream &out) override;
 };
 
 struct const_expr: value_expr {
   std::string expr;
   const_expr(prod *p, sqltype *type_constraint = 0);
-  virtual void out(std::ostream &out) { out << expr; }
-  virtual ~const_expr() { }
+  void out(std::ostream &out) override { out << expr; }
+  ~const_expr() override { }
 };
 
 struct column_reference: value_expr {
   column_reference(prod *p, sqltype *type_constraint = 0);
-  virtual void out(std::ostream &out) { out << reference; }
+  void out(std::ostream &out) override { out << reference; }
   std::string reference;
-  virtual ~column_reference() { }
+  ~column_reference() override { }
 };
 
 struct coalesce : value_expr {
   const char *abbrev_;
   vector<shared_ptr<value_expr> > value_exprs;
-  virtual ~coalesce() { };
+  ~coalesce() override { };
   coalesce(prod *p, sqltype *type_constraint = 0, const char *abbrev = "coalesce");
-  virtual void out(std::ostream &out);
-  virtual void accept(prod_visitor *v) {
+  void out(std::ostream &out) override;
+  void accept(prod_visitor *v) override {
     v->visit(this);
     for (auto p : value_exprs)
       p->accept(v);
@@ -79,39 +79,39 @@ struct coalesce : value_expr {
 };
 
 struct nullif : coalesce {
- virtual ~nullif() { };
+ ~nullif() override { };
      nullif(prod *p, sqltype *type_constraint = 0)
 	  : coalesce(p, type_constraint, "nullif")
 	  { };
 };
 
 struct bool_expr : value_expr {
-  virtual ~bool_expr() { }
+  ~bool_expr() override { }
   bool_expr(prod *p) : value_expr(p) { type = scope->schema->booltype; }
   static shared_ptr<bool_expr> factory(prod *p);
 };
 
 struct truth_value : bool_expr {
-  virtual ~truth_value() { }
+  ~truth_value() override { }
   const char *op;
-  virtual void out(std::ostream &out) { out << op; }
+  void out(std::ostream &out) override { out << op; }
   truth_value(prod *p) : bool_expr(p) {
     op = ( (d6() < 4) ? scope->schema->true_literal : scope->schema->false_literal);
   }
 };
 
 struct null_predicate : bool_expr {
-  virtual ~null_predicate() { }
+  ~null_predicate() override { }
   const char *negate;
   shared_ptr<value_expr> expr;
   null_predicate(prod *p) : bool_expr(p) {
     negate = ((d6()<4) ? "not " : "");
     expr = value_expr::factory(this);
   }
-  virtual void out(std::ostream &out) {
+  void out(std::ostream &out) override {
     out << *expr << " is " << negate << "NULL";
   }
-  virtual void accept(prod_visitor *v) {
+  void accept(prod_visitor *v) override {
     v->visit(this);
     expr->accept(v);
   }
@@ -119,7 +119,7 @@ struct null_predicate : bool_expr {
 
 struct exists_predicate : bool_expr {
   shared_ptr<struct query_spec> subquery;
-  virtual ~exists_predicate() { }
+  ~exists_predicate() override { }
   exists_predicate(prod *p);
   virtual void out(std::ostream &out);
   virtual void accept(prod_visitor *v);
@@ -129,7 +129,7 @@ struct bool_binop : bool_expr {
   shared_ptr<value_expr> lhs, rhs;
   bool_binop(prod *p) : bool_expr(p) { }
   virtual void out(std::ostream &out) = 0;
-  virtual void accept(prod_visitor *v) {
+  void accept(prod_visitor *v) override {
     v->visit(this);
     lhs->accept(v);
     rhs->accept(v);
@@ -139,7 +139,7 @@ struct bool_binop : bool_expr {
 struct bool_term : bool_binop {
   virtual ~bool_term() { }
   const char *op;
-  virtual void out(std::ostream &out) {
+  void out(std::ostream &out) override {
     out << "(" << *lhs << ") ";
     indent(out);
     out << op << " (" << *rhs << ")";
@@ -154,8 +154,8 @@ struct bool_term : bool_binop {
 
 struct distinct_pred : bool_binop {
   distinct_pred(prod *p);
-  virtual ~distinct_pred() { };
-  virtual void out(std::ostream &o) {
+  ~distinct_pred() override { };
+  void out(std::ostream &o) override {
     o << *lhs << " is distinct from " << *rhs;
   }
 };
@@ -163,7 +163,7 @@ struct distinct_pred : bool_binop {
 struct comparison_op : bool_binop {
   op *oper;
   comparison_op(prod *p);
-  virtual ~comparison_op() { };
+  ~comparison_op() override { };
   virtual void out(std::ostream &o) {
     o << *lhs << " " << oper->name << " " << *rhs;
   }
@@ -171,13 +171,13 @@ struct comparison_op : bool_binop {
 
 struct window_function : value_expr {
   virtual void out(std::ostream &out);
-  virtual ~window_function() { }
+  ~window_function() override { }
   window_function(prod *p, sqltype *type_constraint);
   vector<shared_ptr<column_reference> > partition_by;
   vector<shared_ptr<column_reference> > order_by;
   shared_ptr<funcall> aggregate;
   static bool allowed(prod *pprod);
-  virtual void accept(prod_visitor *v) {
+  void accept(prod_visitor *v) override {
     v->visit(this);
     aggregate->accept(v);
     for (auto p : partition_by)

--- a/grammar.cc
+++ b/grammar.cc
@@ -44,7 +44,7 @@ target_table::target_table(prod *p, table *victim) : table_ref(p)
   while (! victim
 	 || victim->schema == "pg_catalog"
 	 || !victim->is_base_table
-	 || !victim->columns().size()) {
+	 || victim->columns().empty()) {
     struct named_relation *pick = random_pick(scope->tables);
     victim = dynamic_cast<table *>(pick);
     retry();
@@ -112,7 +112,7 @@ simple_join_cond::simple_join_cond(prod *p, table_ref &lhs, table_ref &rhs)
 retry:
   named_relation *left_rel = &*random_pick(lhs.refs);
   
-  if (!left_rel->columns().size())
+  if (left_rel->columns().empty())
     { retry(); goto retry; }
 
   named_relation *right_rel = &*random_pick(rhs.refs);
@@ -126,7 +126,7 @@ retry:
       break;
     }
   }
-  if (condition == "") {
+  if (condition.empty()) {
     retry(); goto retry;
   }
 }
@@ -185,7 +185,7 @@ void table_subquery::out(std::ostream &out) {
 }
 
 void from_clause::out(std::ostream &out) {
-  if (! reflist.size())
+  if (reflist.empty())
     return;
   out << "from ";
 
@@ -345,7 +345,7 @@ void modifying_stmt::pick_victim()
     } while (! victim
 	   || victim->schema == "pg_catalog"
 	   || !victim->is_base_table
-	   || !victim->columns().size());
+	   || victim->columns().empty());
 }
 
 modifying_stmt::modifying_stmt(prod *p, struct scope *s, table *victim)
@@ -387,7 +387,7 @@ void insert_stmt::out(std::ostream &out)
 {
   out << "insert into " << victim->ident() << " ";
 
-  if (!value_exprs.size()) {
+  if (value_exprs.empty()) {
     out << "default values";
     return;
   }
@@ -415,12 +415,12 @@ set_list::set_list(prod *p, table *target) : prod(p)
       value_exprs.push_back(expr);
       names.push_back(col.name);
     }
-  } while (!names.size());
+  } while (names.empty());
 }
 
 void set_list::out(std::ostream &out)
 {
-  assert(names.size());
+  assert(!names.empty());
   out << " set ";
   for (size_t i = 0; i < names.size(); i++) {
     indent(out);
@@ -455,7 +455,7 @@ upsert_stmt::upsert_stmt(prod *p, struct scope *s, table *v)
 {
   match();
 
-  if (!victim->constraints.size())
+  if (victim->constraints.empty())
     fail("need table w/ constraint for upsert");
     
   set_list = std::make_shared<struct set_list>(this, victim);

--- a/grammar.cc
+++ b/grammar.cc
@@ -221,7 +221,7 @@ select_list::select_list(prod *p) : prod(p)
     name << "c" << columns++;
     sqltype *t=e->type;
     assert(t);
-    derived_table.columns().push_back(column(name.str(), t));
+    derived_table.columns().emplace_back(name.str(), t);
   } while (d6() > 1);
 }
 

--- a/grammar.cc
+++ b/grammar.cc
@@ -119,7 +119,7 @@ retry:
 
   column &c1 = random_pick(left_rel->columns());
 
-  for (auto c2 : right_rel->columns()) {
+  for (const auto& c2 : right_rel->columns()) {
     if (c1.type == c2.type) {
       condition +=
 	left_rel->ident() + "." + c1.name + " = " + right_rel->ident() + "." + c2.name + " ";
@@ -139,9 +139,9 @@ expr_join_cond::expr_join_cond(prod *p, table_ref &lhs, table_ref &rhs)
      : join_cond(p, lhs, rhs), joinscope(p->scope)
 {
      scope = &joinscope;
-     for (auto ref: lhs.refs)
+     for (const auto& ref: lhs.refs)
 	  joinscope.refs.push_back(&*ref);
-     for (auto ref: rhs.refs)
+     for (const auto& ref: rhs.refs)
 	  joinscope.refs.push_back(&*ref);
      search = bool_expr::factory(this);
 }
@@ -164,9 +164,9 @@ joined_table::joined_table(prod *p) : table_ref(p) {
     type = "right";
   }
 
-  for (auto ref: lhs->refs)
+  for (const auto& ref: lhs->refs)
     refs.push_back(ref);
-  for (auto ref: rhs->refs)
+  for (const auto& ref: rhs->refs)
     refs.push_back(ref);
 }
 
@@ -199,7 +199,7 @@ void from_clause::out(std::ostream &out) {
 
 from_clause::from_clause(prod *p) : prod(p) {
   reflist.push_back(table_ref::factory(this));
-  for (auto r : reflist.back()->refs)
+  for (const auto& r : reflist.back()->refs)
     scope->refs.push_back(&*r);
 
   while (d6() > 5) {
@@ -207,7 +207,7 @@ from_clause::from_clause(prod *p) : prod(p) {
     if (!impedance::matched(typeid(lateral_subquery)))
       break;
     reflist.push_back(make_shared<lateral_subquery>(this));
-    for (auto r : reflist.back()->refs)
+    for (const auto& r : reflist.back()->refs)
       scope->refs.push_back(&*r);
   }
 }
@@ -376,7 +376,7 @@ insert_stmt::insert_stmt(prod *p, struct scope *s, table *v)
 {
   match();
 
-  for (auto col : victim->columns()) {
+  for (const auto& col : victim->columns()) {
     auto expr = value_expr::factory(this, col.type);
     assert(expr->type == col.type);
     value_exprs.push_back(expr);
@@ -408,7 +408,7 @@ void insert_stmt::out(std::ostream &out)
 set_list::set_list(prod *p, table *target) : prod(p)
 {
   do {
-    for (auto col : target->columns()) {
+    for (const auto& col : target->columns()) {
       if (d6() < 4)
 	continue;
       auto expr = value_expr::factory(this, col.type);
@@ -565,7 +565,7 @@ void merge_stmt::out(std::ostream &out)
      indent(out);
      out << "ON " << *join_condition;
      indent(out);
-     for (auto p : clauselist) {
+     for (const auto& p : clauselist) {
        out << *p;
        indent(out);
      }
@@ -577,7 +577,7 @@ void merge_stmt::accept(prod_visitor *v)
   target_table_->accept(v);
   data_source->accept(v);
   join_condition->accept(v);
-  for (auto p : clauselist)
+  for (const auto& p : clauselist)
     p->accept(v);
     
 }
@@ -632,7 +632,7 @@ void when_clause_update::accept(prod_visitor *v)
 when_clause_insert::when_clause_insert(struct merge_stmt *p)
   : when_clause(p)
 {
-  for (auto col : p->victim->columns()) {
+  for (const auto& col : p->victim->columns()) {
     auto expr = value_expr::factory(this, col.type);
     assert(expr->type == col.type);
     exprs.push_back(expr);
@@ -658,7 +658,7 @@ void when_clause_insert::out(std::ostream &out) {
 void when_clause_insert::accept(prod_visitor *v)
 {
   v->visit(this);
-  for (auto p : exprs)
+  for (const auto& p : exprs)
     p->accept(v);
 }
 

--- a/grammar.cc
+++ b/grammar.cc
@@ -255,23 +255,23 @@ struct for_update_verify : prod_visitor {
   virtual void visit(prod *p) {
     if (dynamic_cast<window_function*>(p))
       throw("window function");
-    joined_table* join = dynamic_cast<joined_table*>(p);
+    auto* join = dynamic_cast<joined_table*>(p);
     if (join && join->type != "inner")
       throw("outer join");
-    query_spec* subquery = dynamic_cast<query_spec*>(p);
+    auto* subquery = dynamic_cast<query_spec*>(p);
     if (subquery)
       subquery->set_quantifier = "";
-    table_or_query_name* tab = dynamic_cast<table_or_query_name*>(p);
+    auto* tab = dynamic_cast<table_or_query_name*>(p);
     if (tab) {
-      table *actual_table = dynamic_cast<table*>(tab->t);
+      auto *actual_table = dynamic_cast<table*>(tab->t);
       if (actual_table && !actual_table->is_insertable)
 	throw("read only");
       if (actual_table->name.find("pg_"))
 	throw("catalog");
     }
-    table_sample* sample = dynamic_cast<table_sample*>(p);
+    auto* sample = dynamic_cast<table_sample*>(p);
     if (sample) {
-      table *actual_table = dynamic_cast<table*>(sample->t);
+      auto *actual_table = dynamic_cast<table*>(sample->t);
       if (actual_table && !actual_table->is_insertable)
 	throw("read only");
       if (actual_table->name.find("pg_"))
@@ -500,7 +500,7 @@ common_table_expression::common_table_expression(prod *parent, struct scope *s)
 {
   scope = &myscope;
   do {
-    shared_ptr<query_spec> query = make_shared<query_spec>(this, s);
+    auto query = make_shared<query_spec>(this, s);
     with_queries.push_back(query);
     string alias = scope->stmt_uid("jennifer");
     relation *relation = &query->select_list->derived_table;

--- a/impedance.cc
+++ b/impedance.cc
@@ -71,12 +71,12 @@ void report(std::ostream &out)
   for (auto pair = occurances_in_failed_query.begin();
        pair != occurances_in_failed_query.end();
        ++pair) {
-    out << "{\"prod\": \"" << pretty_type(pair->first) << "\","
-	<< "\"bad\": " << pair->second << ", "
-	<< "\"ok\": " << occurances_in_ok_query[pair->first] << ", "
-	<< "\"limited\": " << limited[pair->first] << ", "
-	<< "\"failed\": " << failed[pair->first] << ", "
-	<< "\"retries\": " << retries[pair->first] << "} ";
+    out << R"({"prod": ")" << pretty_type(pair->first) << R"(",)"
+	<< R"("bad": )" << pair->second << ", "
+	<< R"("ok": )" << occurances_in_ok_query[pair->first] << ", "
+	<< R"("limited": )" << limited[pair->first] << ", "
+	<< R"("failed": )" << failed[pair->first] << ", "
+	<< R"("retries": )" << retries[pair->first] << "} ";
 
     if (next(pair) != occurances_in_failed_query.end())
       out << "," << endl;

--- a/impedance.hh
+++ b/impedance.hh
@@ -15,14 +15,14 @@
 struct impedance_visitor : prod_visitor {
   std::map<const char*, long> &_occured;
   std::map<const char*, bool> found;
-  virtual void visit(struct prod *p);
+  void visit(struct prod *p) override;
   impedance_visitor(std::map<const char*, long> &occured);
-  virtual ~impedance_visitor();
+  ~impedance_visitor() override;
 };
 
 struct impedance_feedback : logger {
-  virtual void executed(prod &query);
-  virtual void error(prod &query, const dut::failure &e);
+  void executed(prod &query) override;
+  void error(prod &query, const dut::failure &e) override;
   impedance_feedback() { }
 };
 

--- a/log.cc
+++ b/log.cc
@@ -61,9 +61,9 @@ void stats_collecting_logger::generated(prod &query)
   stats_visitor v;
   query.accept(&v);
 
-  sum_nodes += v.nodes;
-  sum_height += v.maxlevel;
-  sum_retries += v.retries;
+  sum_nodes += static_cast<float>(v.nodes);
+  sum_height += static_cast<float>(v.maxlevel);
+  sum_retries += static_cast<float>(v.retries);
 }
 
 void cerr_logger::report()

--- a/log.cc
+++ b/log.cc
@@ -32,7 +32,7 @@ struct stats_visitor : prod_visitor {
   int maxlevel = 0;
   long retries = 0;
   map<const char*, long> production_stats;
-  virtual void visit(struct prod *p) {
+  void visit(struct prod *p) override {
     nodes++;
     if (p->level > maxlevel)
       maxlevel = p->level;

--- a/log.cc
+++ b/log.cc
@@ -43,7 +43,7 @@ struct stats_visitor : prod_visitor {
     cerr << "production statistics" << endl;
     vector<pair<const char *, long> > report;
     for (auto p : production_stats)
-      report.push_back(p);
+      report.emplace_back(p);
     stable_sort(report.begin(), report.end(),
 		[](const pair<std::string, long> &a,
 		   const pair<std::string, long> &b)
@@ -76,7 +76,7 @@ void cerr_logger::report()
 
     vector<pair<std::string, long> > report;
     for (auto e : errors) {
-      report.push_back(e);
+      report.emplace_back(e);
     }
     stable_sort(report.begin(), report.end(),
 		[](const pair<std::string, long> &a,

--- a/log.cc
+++ b/log.cc
@@ -129,7 +129,7 @@ void cerr_logger::error(prod &query, const dut::failure &e)
     cerr << "e";
 }
 
-pqxx_logger::pqxx_logger(std::string target, std::string conninfo, struct schema &s)
+pqxx_logger::pqxx_logger(const std::string& target, const std::string& conninfo, struct schema &s)
 {
   c = make_shared<pqxx::connection>(conninfo);
 

--- a/log.hh
+++ b/log.hh
@@ -22,7 +22,7 @@ struct logger {
 
 /// logger to dump all generated queries
 struct query_dumper : logger {
-  virtual void generated(prod &query) {
+  void generated(prod &query) override {
        query.out(std::cout);
        std::cout << ";" << std::endl;
   }
@@ -34,7 +34,7 @@ struct stats_collecting_logger : logger {
   float sum_nodes = 0;
   float sum_height = 0;
   float sum_retries = 0;
-  virtual void generated(prod &query);
+  void generated(prod &query) override;
 };
 
 /// stderr logger
@@ -42,9 +42,9 @@ struct cerr_logger : stats_collecting_logger {
   const int columns = 80;
   std::map<std::string, long> errors;
   virtual void report();
-  virtual void generated(prod &query);
-  virtual void executed(prod &query);
-  virtual void error(prod &query, const dut::failure &e);
+  void generated(prod &query) override;
+  void executed(prod &query) override;
+  void error(prod &query, const dut::failure &e) override;
   void report(prod &p);
 };
 

--- a/log.hh
+++ b/log.hh
@@ -52,9 +52,9 @@ struct cerr_logger : stats_collecting_logger {
 struct pqxx_logger : stats_collecting_logger {
   long id;
   std::shared_ptr<pqxx::connection> c;
-  pqxx_logger(std::string target, std::string conninfo, struct schema &s);
-  virtual void generated(prod &query);
-  virtual void error(prod &query, const dut::failure &e);
+  pqxx_logger(const std::string& target, const std::string& conninfo, struct schema &s);
+  void generated(prod &query) override;
+  void error(prod &query, const dut::failure &e) override;
 };
 
 #endif

--- a/postgres.cc
+++ b/postgres.cc
@@ -18,7 +18,7 @@ static regex e_syntax("ERROR:  syntax error at or near(\n|.)*");
 
 bool pg_type::consistent(sqltype *rvalue)
 {
-  pg_type *t = dynamic_cast<pg_type*>(rvalue);
+  auto *t = dynamic_cast<pg_type*>(rvalue);
 
   if (!t) {
     cerr << "unknown type: " << rvalue->name  << endl;
@@ -116,19 +116,19 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "from pg_type ");
   
   for (auto row = r.begin(); row != r.end(); ++row) {
-    string name(row[0].as<string>());
-    OID oid(row[1].as<OID>());
-    string typdelim(row[2].as<string>());
-    OID typrelid(row[3].as<OID>());
-    OID typelem(row[4].as<OID>());
-    OID typarray(row[5].as<OID>());
-    string typtype(row[6].as<string>());
+    auto name(row[0].as<string>());
+    auto oid(row[1].as<OID>());
+    auto typdelim(row[2].as<string>());
+    auto typrelid(row[3].as<OID>());
+    auto typelem(row[4].as<OID>());
+    auto typarray(row[5].as<OID>());
+    auto typtype(row[6].as<string>());
     //       if (schema == "pg_catalog")
     // 	continue;
     //       if (schema == "information_schema")
     // 	continue;
 
-    pg_type *t = new pg_type(name,oid,typdelim[0],typrelid, typelem, typarray, typtype[0]);
+    auto *t = new pg_type(name,oid,typdelim[0],typrelid, typelem, typarray, typtype[0]);
     oid2type[oid] = t;
     name2type[name] = t;
     types.push_back(t);
@@ -150,9 +150,9 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "from information_schema.tables");
 	     
   for (auto row = r.begin(); row != r.end(); ++row) {
-    string schema(row[1].as<string>());
-    string insertable(row[2].as<string>());
-    string table_type(row[3].as<string>());
+    auto schema(row[1].as<string>());
+    auto insertable(row[2].as<string>());
+    auto table_type(row[3].as<string>());
 
 	if (no_catalog && ((schema == "pg_catalog") || (schema == "information_schema")))
 		continue;

--- a/postgres.cc
+++ b/postgres.cc
@@ -353,7 +353,7 @@ void dut_libpq::command(const std::string &stmt)
 
 	if (CONNECTION_OK != PQstatus(conn)) {
             PQfinish(conn);
-	    conn = 0;
+	    conn = nullptr;
 	    throw dut::broken(error_string.c_str(), sqlstate_string.c_str());
 	}
 	if (sqlstate_string == "42601")

--- a/postgres.cc
+++ b/postgres.cc
@@ -60,7 +60,7 @@ bool pg_type::consistent(sqltype *rvalue)
   }
 }
 
-dut_pqxx::dut_pqxx(std::string conninfo)
+dut_pqxx::dut_pqxx(const std::string& conninfo)
   : c(conninfo)
 {
      c.set_variable("statement_timeout", "'1s'");

--- a/postgres.cc
+++ b/postgres.cc
@@ -157,10 +157,10 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	if (no_catalog && ((schema == "pg_catalog") || (schema == "information_schema")))
 		continue;
       
-    tables.push_back(table(row[0].as<string>(),
+    tables.emplace_back(row[0].as<string>(),
 			   schema,
-			   ((insertable == "YES") ? true : false),
-			   ((table_type == "BASE TABLE") ? true : false)));
+         (insertable == "YES"),
+         (table_type == "BASE TABLE"));
   }
 	     
   cerr << "done." << endl;

--- a/postgres.hh
+++ b/postgres.hh
@@ -51,8 +51,8 @@ struct schema_pqxx : public schema {
 
 struct dut_pqxx : dut_base {
   pqxx::connection c;
-  virtual void test(const std::string &stmt);
-  dut_pqxx(std::string conninfo);
+  void test(const std::string &stmt) override;
+  dut_pqxx(const std::string& conninfo);
 };
 
 struct dut_libpq : dut_base {

--- a/postgres.hh
+++ b/postgres.hh
@@ -33,7 +33,7 @@ struct pg_type : sqltype {
     : sqltype(name), oid_(oid), typdelim_(typdelim), typrelid_(typrelid),
       typelem_(typelem), typarray_(typarray), typtype_(typtype) { }
 
-  virtual bool consistent(struct sqltype *rvalue);
+  bool consistent(struct sqltype *rvalue) override;
   bool consistent_(sqltype *rvalue);
 };
 
@@ -43,7 +43,7 @@ struct schema_pqxx : public schema {
   map<OID, pg_type*> oid2type;
   map<string, pg_type*> name2type;
 
-  virtual std::string quote_name(const std::string &id) {
+  std::string quote_name(const std::string &id) override {
     return c.quote_name(id);
   }
   schema_pqxx(std::string &conninfo, bool no_catalog);

--- a/random.hh
+++ b/random.hh
@@ -14,7 +14,7 @@ namespace smith {
 }
 
 template<typename T> T& random_pick(std::vector<T>& container) {
-  if (!container.size())
+  if (container.empty())
     throw std::runtime_error("No candidates available");
   
   std::uniform_int_distribution<int> pick(0, container.size()-1);

--- a/relmodel.cc
+++ b/relmodel.cc
@@ -2,7 +2,7 @@
 
 map<string, sqltype*> sqltype::typemap;
 
-sqltype * sqltype::get(string n)
+sqltype * sqltype::get(const string& n)
 {
   if (typemap.count(n))
     return typemap[n];

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -4,6 +4,7 @@
 #ifndef RELMODEL_HH
 #define RELMODEL_HH
 #include <string>
+#include <utility>
 #include <vector>
 #include <map>
 #include <utility>
@@ -37,8 +38,8 @@ struct sqltype {
 struct column {
   string name;
   sqltype *type;
-  column(string name) : name(name) { }
-  column(string name, sqltype *t) : name(name), type(t) {
+  column(string name) : name(std::move(name)) { }
+  column(string name, sqltype *t) : name(std::move(name)), type(t) {
     assert(t);
   }
 };
@@ -52,14 +53,14 @@ struct named_relation : relation {
   string name;
   virtual string ident() { return name; }
   virtual ~named_relation() { }
-  named_relation(string n) : name(n) { }
+  named_relation(string n) : name(std::move(n)) { }
 };
 
 struct aliased_relation : named_relation {
   relation *rel;
-  virtual ~aliased_relation() { }
-  aliased_relation(string n, relation* r) : named_relation(n), rel(r) { }
-  virtual vector<column>& columns() { return rel->columns(); }
+  ~aliased_relation() override { }
+  aliased_relation(string n, relation* r) : named_relation(std::move(n)), rel(r) { }
+  vector<column>& columns() override { return rel->columns(); }
 };
 
 struct table : named_relation {
@@ -68,8 +69,8 @@ struct table : named_relation {
   bool is_base_table;
   vector<string> constraints;
   table(string name, string schema, bool insertable, bool base_table)
-    : named_relation(name),
-      schema(schema),
+    : named_relation(std::move(name)),
+      schema(std::move(schema)),
       is_insertable(insertable),
       is_base_table(base_table) { }
   string ident() override { return schema + "." + name; }
@@ -120,7 +121,7 @@ struct op {
   sqltype *right;
   sqltype *result;
   op(string n,sqltype *l,sqltype *r, sqltype *res)
-    : name(n), left(l), right(r), result(res) { }
+    : name(std::move(n)), left(l), right(r), result(res) { }
   op() { }
 };
 
@@ -131,7 +132,7 @@ struct routine {
   sqltype *restype;
   string name;
   routine(string schema, string specific_name, sqltype* data_type, string name)
-    : specific_name(specific_name), schema(schema), restype(data_type), name(name) {
+    : specific_name(std::move(specific_name)), schema(std::move(schema)), restype(data_type), name(std::move(name)) {
     assert(data_type);
   }
   virtual string ident() {

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -72,8 +72,8 @@ struct table : named_relation {
       schema(schema),
       is_insertable(insertable),
       is_base_table(base_table) { }
-  virtual string ident() { return schema + "." + name; }
-  virtual ~table() { };
+  string ident() override { return schema + "." + name; }
+  ~table() override { };
 };
 
 struct scope {

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -20,8 +20,8 @@ using std::shared_ptr;
 struct sqltype {
   string name;
   static map<string, struct sqltype*> typemap;
-  static struct sqltype *get(string s);
-  sqltype(string n) : name(n) { }
+  static struct sqltype *get(const string& s);
+  sqltype(string n) : name(std::move(n)) { }
 
   /** This function is used to model postgres-style pseudotypes.
       A generic type is consistent with a more concrete type.

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -85,7 +85,7 @@ struct scope {
   struct schema *schema;
   /// Counters for prefixed stmt-unique identifiers
   shared_ptr<map<string,unsigned int> > stmt_seq;
-  scope(struct scope *parent = 0) : parent(parent) {
+  scope(struct scope *parent = nullptr) : parent(parent) {
     if (parent) {
       schema = parent->schema;
       tables = parent->tables;

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -98,7 +98,7 @@ struct scope {
     for (auto r : refs)
       for (auto c : r->columns())
 	if (t->consistent(c.type))
-	  result.push_back(make_pair(r,c));
+	  result.emplace_back(r,c);
     return result;
   }
   /** Generate unique identifier with prefix. */

--- a/relmodel.hh
+++ b/relmodel.hh
@@ -135,7 +135,7 @@ struct routine {
     assert(data_type);
   }
   virtual string ident() {
-    if (schema.size())
+    if (!schema.empty())
       return schema + "." + name;
     else
       return name;

--- a/schema.cc
+++ b/schema.cc
@@ -23,7 +23,7 @@ void schema::generate_indexes() {
       if (!type->consistent(r.restype))
 	continue;
       routines_returning_type.insert(pair<sqltype*, routine*>(type, &r));
-      if(!r.argtypes.size())
+      if(r.argtypes.empty())
 	parameterless_routines_returning_type.insert(pair<sqltype*, routine*>(type, &r));
     }
     

--- a/schema.hh
+++ b/schema.hh
@@ -46,7 +46,7 @@ struct schema {
   
   virtual std::string quote_name(const std::string &id) = 0;
   
-  void summary() {
+  void summary() const {
     std::cout << "Found " << tables.size() <<
       " user table(s) in information schema." << std::endl;
   }

--- a/sqlite.cc
+++ b/sqlite.cc
@@ -53,7 +53,7 @@ extern "C" int table_callback(void *arg, int argc, char **argv, char **azColName
 extern "C" int column_callback(void *arg, int argc, char **argv, char **azColName)
 {
   (void) argc; (void) azColName;
-  table *tab = (table *)arg;
+  auto *tab = (table *)arg;
   column c(argv[1], sqltype::get(argv[2]));
   tab->columns().push_back(c);
   return 0;

--- a/sqlite.cc
+++ b/sqlite.cc
@@ -256,7 +256,7 @@ schema_sqlite::schema_sqlite(std::string &conninfo, bool no_catalog)
 
   generate_indexes();
   sqlite3_close(db);
-  db = 0;
+  db = nullptr;
 }
 
 dut_sqlite::dut_sqlite(std::string &conninfo)

--- a/sqlite.cc
+++ b/sqlite.cc
@@ -15,7 +15,7 @@ using boost::regex_match;
 
 using namespace std;
 
-static regex e_syntax("near \".*\": syntax error");
+static regex e_syntax(R"(near ".*": syntax error)");
 static regex e_user_abort("callback requested query abort");
   
 extern "C"  {

--- a/sqlite.cc
+++ b/sqlite.cc
@@ -117,12 +117,12 @@ schema_sqlite::schema_sqlite(std::string &conninfo, bool no_catalog)
 
   cerr << "Loading columns and constraints...";
 
-  for (auto t = tables.begin(); t != tables.end(); ++t) {
+  for (auto & table : tables) {
     string q("pragma table_info(");
-    q += t->name;
+    q += table.name;
     q += ");";
 
-    rc = sqlite3_exec(db, q.c_str(), column_callback, (void *)&*t, &zErrMsg);
+    rc = sqlite3_exec(db, q.c_str(), column_callback, (void *)&table, &zErrMsg);
     if (rc!=SQLITE_OK) {
       auto e = std::runtime_error(zErrMsg);
       sqlite3_free(zErrMsg);

--- a/sqlite.hh
+++ b/sqlite.hh
@@ -23,13 +23,13 @@ struct sqlite_connection {
 
 struct schema_sqlite : schema, sqlite_connection {
   schema_sqlite(std::string &conninfo, bool no_catalog);
-  virtual std::string quote_name(const std::string &id) {
+  std::string quote_name(const std::string &id) override {
     return id;
   }
 };
 
 struct dut_sqlite : dut_base, sqlite_connection {
-  virtual void test(const std::string &stmt);
+  void test(const std::string &stmt) override;
   dut_sqlite(std::string &conninfo);
 };
 

--- a/sqlite.hh
+++ b/sqlite.hh
@@ -13,8 +13,8 @@ extern "C"  {
 #include "dut.hh"
 
 struct sqlite_connection {
-  sqlite3 *db;
-  char *zErrMsg = 0;
+  sqlite3 *db{nullptr};
+  char *zErrMsg{nullptr};
   int rc;
   void q(const char *query);
   sqlite_connection(std::string &conninfo);

--- a/sqlsmith.cc
+++ b/sqlsmith.cc
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 	loggers.push_back(make_shared<query_dumper>());
 
       if (options.count("dry-run")) {
-	while (1) {
+	while (true) {
 	  shared_ptr<prod> gen = statement_factory(&scope);
 	  gen->out(cout);
 	  for (auto l : loggers)
@@ -190,10 +190,10 @@ int main(int argc, char *argv[])
       else
 	dut = make_shared<dut_libpq>(options["target"]);
 
-      while (1) /* Loop to recover connection loss */
+      while (true) /* Loop to recover connection loss */
       {
 	try {
-            while (1) { /* Main loop */
+            while (true) { /* Main loop */
 
 	    if (options.count("max-queries")
 		&& (++queries_generated > stol(options["max-queries"]))) {

--- a/sqlsmith.cc
+++ b/sqlsmith.cc
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
 	    /* Invoke top-level production to generate AST */
 	    shared_ptr<prod> gen = statement_factory(&scope);
 
-	    for (auto l : loggers)
+	    for (const auto& l : loggers)
 	      l->generated(*gen);
 	  
 	    /* Generate SQL from AST */
@@ -215,10 +215,10 @@ int main(int argc, char *argv[])
 	    /* Try to execute it */
 	    try {
 	      dut->test(s.str());
-	      for (auto l : loggers)
+	      for (const auto& l : loggers)
 		l->executed(*gen);
 	    } catch (const dut::failure &e) {
-	      for (auto l : loggers)
+	      for (const auto& l : loggers)
 		try {
 		  l->error(*gen, e);
 		} catch (runtime_error &e) {


### PR DESCRIPTION
Just a few optimizations that should make the code more readable and increase the performance in some cases:

- replaced `string literals` with `raw string literals` where quoting was required before
- made members `static`/`const` where possible
- used `override` instead of `virtual` for derived objects
- replaced a bunch of implicit copies of objects with `const &`
- replaced `size()` with `empty()` where possible
- simplified some boolean expressions and loops
- replaced `0` with `nullptr` for ptr types

and some other very minor changes.

I grouped the changes by their nature in commits, so cherry picking should be easy.

Details, why i think these changes are nice are in the individual commit messages.
