### PR TITLE
Replaced std::multimap with std::map<key,std::vector<>>

### DIFF
--- a/expr.cc
+++ b/expr.cc
@@ -145,7 +145,7 @@ comparison_op::comparison_op(prod *p) : bool_binop(p)
   auto &idx = p->scope->schema->operators_returning_type;
 
   auto iters = idx.equal_range(scope->schema->booltype);
-  oper = random_pick<>(iters)->second;
+  oper = random_pick(random_pick(iters)->second);
 
   lhs = value_expr::factory(this, oper->left);
   rhs = value_expr::factory(this, oper->right);
@@ -221,10 +221,10 @@ funcall::funcall(prod *p, sqltype *type_constraint, bool agg)
  retry:
   
   if (!type_constraint) {
-    proc = random_pick(idx.begin(), idx.end())->second;
+    proc = random_pick(random_pick(idx.begin(), idx.end())->second);
   } else {
     auto iters = idx.equal_range(type_constraint);
-    proc = random_pick<>(iters)->second;
+    proc = random_pick(random_pick(iters)->second);
     if (proc && !type_constraint->consistent(proc->restype)) {
       retry();
       goto retry;
@@ -283,7 +283,7 @@ atomic_subselect::atomic_subselect(prod *p, sqltype *type_constraint)
     if (type_constraint) {
       auto idx = scope->schema->aggregates_returning_type;
       auto iters = idx.equal_range(type_constraint);
-      agg = random_pick<>(iters)->second;
+      agg = random_pick(random_pick(iters)->second);
     } else {
       agg = &random_pick<>(scope->schema->aggregates);
     }
@@ -299,7 +299,7 @@ atomic_subselect::atomic_subselect(prod *p, sqltype *type_constraint)
     auto idx = scope->schema->tables_with_columns_of_type;
     col = 0;
     auto iters = idx.equal_range(type_constraint);
-    tab = random_pick<>(iters)->second;
+    tab = random_pick(random_pick(iters)->second);
 
     for (auto &cand : tab->columns()) {
       if (type_constraint->consistent(cand.type)) {

--- a/schema.cc
+++ b/schema.cc
@@ -16,21 +16,21 @@ void schema::generate_indexes() {
     assert(type);
     for(auto &r: aggregates) {
       if (type->consistent(r.restype))
-	aggregates_returning_type.insert(pair<sqltype*, routine*>(type, &r));
+	      aggregates_returning_type[type].push_back(&r);
     }
 
     for(auto &r: routines) {
       if (!type->consistent(r.restype))
 	continue;
-      routines_returning_type.insert(pair<sqltype*, routine*>(type, &r));
+      routines_returning_type[type].push_back(&r);
       if(!r.argtypes.size())
-	parameterless_routines_returning_type.insert(pair<sqltype*, routine*>(type, &r));
+	      parameterless_routines_returning_type[type].push_back(&r);
     }
     
     for (auto &t: tables) {
       for (auto &c: t.columns()) {
 	if (type->consistent(c.type)) {
-	  tables_with_columns_of_type.insert(pair<sqltype*, table*>(type, &t));
+	  tables_with_columns_of_type[type].push_back(&t);
 	  break;
 	}
       }
@@ -38,12 +38,12 @@ void schema::generate_indexes() {
 
     for (auto &concrete: types) {
       if (type->consistent(concrete))
-	concrete_type.insert(pair<sqltype*, sqltype*>(type, concrete));
+	      concrete_type[type].push_back(concrete);
     }
 
     for (auto &o: operators) {
       if (type->consistent(o.result))
-	operators_returning_type.insert(pair<sqltype*, op*>(type, &o));
+	      operators_returning_type[type].push_back(&o);
     }
   }
 

--- a/schema.hh
+++ b/schema.hh
@@ -30,12 +30,12 @@ struct schema {
   std::multimap<typekey, op> index;
   typedef std::multimap<typekey, op>::iterator op_iterator;
 
-  std::multimap<sqltype*, routine*> routines_returning_type;
-  std::multimap<sqltype*, routine*> aggregates_returning_type;
-  std::multimap<sqltype*, routine*> parameterless_routines_returning_type;
-  std::multimap<sqltype*, table*> tables_with_columns_of_type;
-  std::multimap<sqltype*, op*> operators_returning_type;
-  std::multimap<sqltype*, sqltype*> concrete_type;
+  std::map<sqltype*, std::vector<routine*>>  routines_returning_type;
+  std::map<sqltype*, std::vector<routine*>>  aggregates_returning_type;
+  std::map<sqltype*, std::vector<routine*>>  parameterless_routines_returning_type;
+  std::map<sqltype*, std::vector<table*>> tables_with_columns_of_type;
+  std::map<sqltype*, std::vector<op*>> operators_returning_type;
+  std::map<sqltype*, std::vector<sqltype*>> concrete_type;
   std::vector<table*> base_tables;
 
   string version;


### PR DESCRIPTION
A callgrind analysis showed, that we spend much of our time inside the
multimap functions. It seems that the multimap implementation provided
by gcc requires memory allocations for equal_range and other lookups.

This change results in a 120% performance increase on my system.