### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+sqlsmith (1.4-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on libpqxx-dev.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 17 Mar 2022 12:49:00 -0000
+
 sqlsmith (1.4-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends:
  autoconf-archive,
  debhelper-compat (= 12),
  libpq-dev,
- libpqxx-dev (>= 4.0),
+ libpqxx-dev,
  libsqlite3-dev,
  libssl-dev,
 


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/sqlsmith/45415031-7767-42c2-9327-823073f73c60.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a8/240d2c7f6c41c001a8d70dd6c67f4a97c5574a.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/f6/6b403b9d7235b2e20ee6088336d5cf0932ee29.debug

No differences were encountered between the control files of package \*\*sqlsmith\*\*
### Control files of package sqlsmith-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-f66b403b9d7235b2e20ee6088336d5cf0932ee29-] {+a8240d2c7f6c41c001a8d70dd6c67f4a97c5574a+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/45415031-7767-42c2-9327-823073f73c60/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/45415031-7767-42c2-9327-823073f73c60/diffoscope)).
