### PR TITLE
Support building with libpqxx 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(SQLsmith LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 include(FeatureTests)
@@ -26,9 +26,15 @@ if (NOT USE_UPSTREAM_LIBPQXX)
     # This check is done by the CMakeLists.txt of the libpqxx project otherwise
     find_package(PQXX REQUIRED)
 
-    if (PQXX_VERSION GREATER 7.0)
+    if (PQXX_VERSION VERSION_GREATER 7.0 AND PQXX_VERSION VERSION_LESS 8.0)
         set(HAVE_LIBPQXX7 TRUE)
-    endif (PQXX_VERSION GREATER 7.0)
+        set_target_properties(sqlsmith PROPERTIES CXX_STANDARD 17)
+    endif ()
+
+    if (PQXX_VERSION VERSION_GREATER 8.0)
+        set(HAVE_LIBPQXX8 TRUE)
+        set_target_properties(sqlsmith PROPERTIES CXX_STANDARD 20)
+    endif()
 
     target_link_libraries(sqlsmith PQXX::PQXX)
 else (NOT USE_UPSTREAM_LIBPQXX)

--- a/config_h.cmake.in
+++ b/config_h.cmake.in
@@ -7,6 +7,7 @@
 #cmakedefine HAVE_BOOST_REGEX 1
 
 #cmakedefine HAVE_LIBPQXX7 1
+#cmakedefine HAVE_LIBPQXX8 1
 
 #cmakedefine HAVE_LIBSQLITE3 1
 #cmakedefine HAVE_MONETDB 1

--- a/configure.ac
+++ b/configure.ac
@@ -6,17 +6,24 @@ AC_PROG_CXX
 
 AX_LIB_POSTGRESQL()
 
-PKG_CHECK_MODULES(LIBPQXX, libpqxx < 7.0,
+PKG_CHECK_MODULES([LIBPQXX], [libpqxx < 7.0],
         [AX_CXX_COMPILE_STDCXX_11(noext,mandatory)],
-        [PKG_CHECK_MODULES([LIBPQXX], [libpqxx >= 7.0],
+        [PKG_CHECK_MODULES([LIBPQXX], [libpqxx < 8.0],
                  [libpqxx7=yes],
-                 []
+                 [PKG_CHECK_MODULES([LIBPQXX], [libpqxx >= 8.0],
+                          [libpqxx8=yes]
+                          []
+                  )]
          )]
 )
 
 AS_IF([test "x$libpqxx7" = "xyes"], AC_MSG_NOTICE([libpqxx version >= 7 detected]), [])
 AS_IF([test "x$libpqxx7" = "xyes"], [AC_DEFINE([HAVE_LIBPQXX7], [1], [define if libpqxx >= 7 is used])], [])
 AS_IF([test "x$libpqxx7" = "xyes"], [AX_CXX_COMPILE_STDCXX_17(noext,mandatory)], [])
+
+AS_IF([test "x$libpqxx8" = "xyes"], AC_MSG_NOTICE([libpqxx version >= 8 detected]), [])
+AS_IF([test "x$libpqxx8" = "xyes"], [AC_DEFINE([HAVE_LIBPQXX8], [1], [define if libpqxx >= 8 is used])], [])
+AS_IF([test "x$libpqxx8" = "xyes"], [AX_CXX_COMPILE_STDCXX(20,noext,mandatory)], [])
 
 PKG_CHECK_MODULES(MONETDB_MAPI, monetdb-mapi >= 11.23.0,
 		[AC_DEFINE([HAVE_MONETDB], [1], [define if the MonetDB client library is available])],

--- a/grammar.cc
+++ b/grammar.cc
@@ -82,7 +82,7 @@ table_subquery::table_subquery(prod *p, bool lateral)
   : table_ref(p), is_lateral(lateral) {
   query = make_shared<query_spec>(this, scope, lateral);
   string alias = scope->stmt_uid("subq");
-  relation *aliased_rel = &query->select_list->derived_table;
+  auto *aliased_rel = &query->select_list->derived_table;
   refs.push_back(make_shared<aliased_relation>(alias, aliased_rel));
 }
 
@@ -503,7 +503,7 @@ common_table_expression::common_table_expression(prod *parent, struct scope *s)
     shared_ptr<query_spec> query = make_shared<query_spec>(this, s);
     with_queries.push_back(query);
     string alias = scope->stmt_uid("jennifer");
-    relation *relation = &query->select_list->derived_table;
+    auto *relation = &query->select_list->derived_table;
     auto aliased_rel = make_shared<aliased_relation>(alias, relation);
     refs.push_back(aliased_rel);
     scope->tables.push_back(&*aliased_rel);

--- a/log.cc
+++ b/log.cc
@@ -146,7 +146,7 @@ pqxx_logger::pqxx_logger(std::string target, std::string conninfo, struct schema
   ostringstream seed;
   seed << smith::rng;
 
-#ifdef HAVE_LIBPQXX7
+#if defined(HAVE_LIBPQXX7) || defined(HAVE_LIBPQXX8)
   result r = w.exec_prepared("instance", GITREV, target, hostname, s.version, seed.str());
 #else
   result r = w.prepared("instance")(GITREV)(target)(hostname)(s.version)(seed.str()).exec();
@@ -173,7 +173,7 @@ void pqxx_logger::error(prod &query, const dut::failure &e)
   work w(*c);
   ostringstream s;
   s << query;
-#ifdef HAVE_LIBPQXX7
+#if defined(HAVE_LIBPQXX7) || defined(HAVE_LIBPQXX8)
   w.exec_prepared("error", e.what(), s.str(), e.sqlstate);
 #else
   w.prepared("error")(e.what())(s.str())(e.sqlstate).exec();
@@ -188,7 +188,7 @@ void pqxx_logger::generated(prod &query)
     work w(*c);
     ostringstream s;
     impedance::report(s);
-#ifdef HAVE_LIBPQXX7
+#if defined(HAVE_LIBPQXX7) || defined(HAVE_LIBPQXX8)
     w.exec_prepared("stat", queries, sum_height/queries, sum_nodes/queries, sum_retries/queries, s.str());
 #else
     w.prepared("stat")(queries)(sum_height/queries)(sum_nodes/queries)(sum_retries/queries)(s.str()).exec();

--- a/postgres.cc
+++ b/postgres.cc
@@ -73,7 +73,7 @@ dut_pqxx::dut_pqxx(std::string conninfo)
 void dut_pqxx::test(const std::string &stmt)
 {
   try {
-#ifndef HAVE_LIBPQXX7
+#if !defined(HAVE_LIBPQXX7) && !defined(HAVE_LIBPQXX8)
     if(!c.is_open())
        c.activate();
 #endif
@@ -120,6 +120,16 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "from pg_type ");
   
   for (auto row = r.begin(); row != r.end(); ++row) {
+#ifdef HAVE_LIBPQXX8
+    pqxx::row_ref row_ref = row[0];
+    string name(row_ref[0].as<string>());
+    OID oid(row_ref[1].as<OID>());
+    string typdelim(row_ref[2].as<string>());
+    OID typrelid(row_ref[3].as<OID>());
+    OID typelem(row_ref[4].as<OID>());
+    OID typarray(row_ref[5].as<OID>());
+    string typtype(row_ref[6].as<string>());
+#else
     string name(row[0].as<string>());
     OID oid(row[1].as<OID>());
     string typdelim(row[2].as<string>());
@@ -127,6 +137,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
     OID typelem(row[4].as<OID>());
     OID typarray(row[5].as<OID>());
     string typtype(row[6].as<string>());
+#endif
     //       if (schema == "pg_catalog")
     // 	continue;
     //       if (schema == "information_schema")
@@ -154,14 +165,26 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
 	     "from information_schema.tables");
 	     
   for (auto row = r.begin(); row != r.end(); ++row) {
+#ifdef HAVE_LIBPQXX8
+    pqxx::row_ref row_ref = row[0];
+    string schema(row_ref[1].as<string>());
+    string insertable(row_ref[2].as<string>());
+    string table_type(row_ref[3].as<string>());
+#else
     string schema(row[1].as<string>());
     string insertable(row[2].as<string>());
     string table_type(row[3].as<string>());
+#endif
 
 	if (no_catalog && ((schema == "pg_catalog") || (schema == "information_schema")))
 		continue;
       
-    tables.push_back(table(row[0].as<string>(),
+    tables.push_back(
+#ifdef HAVE_LIBPQXX8
+			   table(row[0][0].as<string>(),
+#else
+			   table(row[0].as<string>(),
+#endif
 			   schema,
 			   ((insertable == "YES") ? true : false),
 			   ((table_type == "BASE TABLE") ? true : false)));
@@ -288,7 +311,7 @@ schema_pqxx::schema_pqxx(std::string &conninfo, bool no_catalog) : c(conninfo)
     }
   }
   cerr << "done." << endl;
-#ifdef HAVE_LIBPQXX7
+#if defined(HAVE_LIBPQXX7) || defined(HAVE_LIBPQXX8)
   c.close();
 #else
   c.disconnect();


### PR DESCRIPTION
Starting with version 8.0.0, libpqxx requires C++20. The commit updates both the autotools and cmake builds to detect if sqlsmith is compiling against libpqxx and set the C++ standard appropriately.